### PR TITLE
rules: add rule engine, optimize pipeline, and markdown reporter

### DIFF
--- a/afterburner/models/findings.py
+++ b/afterburner/models/findings.py
@@ -1,0 +1,22 @@
+"""Finding and severity models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Severity(str, Enum):
+    CRITICAL = "critical"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass
+class ReportFinding:
+    rule_id: str
+    severity: Severity
+    title: str
+    detail: str
+    fix: str | None = None
+    confidence: float = field(default=1.0)

--- a/afterburner/models/report.py
+++ b/afterburner/models/report.py
@@ -1,0 +1,36 @@
+"""Report model: mission + findings + risk scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from afterburner.models.findings import ReportFinding, Severity
+from afterburner.models.mission import Mission
+
+
+@dataclass
+class Report:
+    mission: Mission
+    findings: list[ReportFinding] = field(default_factory=list)
+
+    def risk_score(self) -> int:
+        """0–100 score. Higher is better. Clamped to 0."""
+        penalty = sum(
+            15
+            if f.severity == Severity.CRITICAL
+            else 5
+            if f.severity == Severity.WARNING
+            else 1
+            for f in self.findings
+        )
+        return max(0, 100 - penalty)
+
+    def risk_label(self) -> str:
+        s = self.risk_score()
+        if s >= 80:
+            return "LOW"
+        if s >= 50:
+            return "MODERATE"
+        if s >= 25:
+            return "HIGH"
+        return "CRITICAL"

--- a/afterburner/optimize/engine.py
+++ b/afterburner/optimize/engine.py
@@ -1,0 +1,82 @@
+"""Optimization orchestrator: backup, transform, report."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from afterburner.optimize.rewrite import ChangeEntry, repack_optimized
+
+
+@dataclass
+class OptimizeResult:
+    source: Path
+    output: Path
+    backup: Path
+    changes: list[ChangeEntry] = field(default_factory=list)
+    bytes_before: int = 0
+    bytes_after: int = 0
+
+    @property
+    def bytes_saved(self) -> int:
+        return self.bytes_before - self.bytes_after
+
+    @property
+    def pct_saved(self) -> float:
+        if self.bytes_before == 0:
+            return 0.0
+        return self.bytes_saved / self.bytes_before
+
+
+def run_safe_optimizations(
+    miz_path: Path,
+    output: Path | None = None,
+) -> OptimizeResult:
+    """
+    Apply all safe, zero-risk optimizations to *miz_path*.
+
+    *output* defaults to ``<stem>.optimized.miz`` in the same directory.
+    Refuses to overwrite *miz_path* — caller must pass a different path.
+
+    Always writes a ``.bak`` copy of the original before producing output.
+    """
+    miz_path = miz_path.resolve()
+
+    if output is None:
+        output = miz_path.with_name(miz_path.stem + ".optimized.miz")
+    else:
+        output = output.resolve()
+
+    if output == miz_path:
+        raise ValueError(
+            f"Output path is the same as input: {miz_path}. "
+            "Use a different --output path."
+        )
+
+    if output.exists():
+        raise FileExistsError(f"Output already exists: {output}")
+
+    # Create backup before touching anything
+    backup = miz_path.with_suffix(".miz.bak")
+    shutil.copy2(miz_path, backup)
+
+    bytes_before = miz_path.stat().st_size
+
+    try:
+        changes = repack_optimized(miz_path, output)
+    except Exception:
+        # If optimization fails, remove the half-written output if it exists
+        output.unlink(missing_ok=True)
+        raise
+
+    bytes_after = output.stat().st_size
+
+    return OptimizeResult(
+        source=miz_path,
+        output=output,
+        backup=backup,
+        changes=changes,
+        bytes_before=bytes_before,
+        bytes_after=bytes_after,
+    )

--- a/afterburner/optimize/rewrite.py
+++ b/afterburner/optimize/rewrite.py
@@ -1,0 +1,116 @@
+"""ZIP-level repack with safe transforms applied."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from afterburner.optimize.safe_fixes import is_junk, normalize_path
+
+
+@dataclass
+class ChangeEntry:
+    transform_id: str
+    status: str  # "applied" | "skipped" | "unsafe"
+    detail: str
+    bytes_saved: int = field(default=0)
+
+
+def repack_optimized(source: Path, dest: Path) -> list[ChangeEntry]:
+    """
+    Repack *source* .miz into *dest* with all safe transforms applied.
+
+    Writes to a temp file then atomically renames to *dest* — if anything
+    fails mid-write no partial file is left behind.  *dest* must not already
+    exist when this function is called.
+    """
+    changes: list[ChangeEntry] = []
+
+    with zipfile.ZipFile(source, "r") as src_zf:
+        raw_entries = src_zf.infolist()
+        kept: list[
+            tuple[str, bytes, int]
+        ] = []  # (arc_name, data, original_compress_size)
+
+        for entry in raw_entries:
+            if entry.filename.endswith("/"):
+                continue  # directory entries — DCS doesn't use them
+
+            name = entry.filename
+
+            # SAFE_001: strip junk
+            if is_junk(name):
+                changes.append(
+                    ChangeEntry(
+                        transform_id="SAFE_001",
+                        status="applied",
+                        detail=f"Removed junk entry: {name}",
+                        bytes_saved=entry.compress_size,
+                    )
+                )
+                continue
+
+            # SAFE_002: normalize path separators
+            normalized = normalize_path(name)
+            if normalized != name:
+                changes.append(
+                    ChangeEntry(
+                        transform_id="SAFE_002",
+                        status="applied",
+                        detail=f"Normalized path: {name!r} → {normalized!r}",
+                    )
+                )
+
+            kept.append((normalized, src_zf.read(entry.filename), entry.compress_size))
+
+    # Ensure `mission` is first entry (DCS requirement)
+    kept.sort(key=lambda t: (0 if t[0] == "mission" else 1, t[0]))
+
+    # Write to a temp file in the same directory (ensures atomic rename works
+    # across filesystems that require same-device moves)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path_str = tempfile.mkstemp(dir=dest.parent, suffix=".miz.tmp")
+    tmp_path = Path(tmp_path_str)
+    try:
+        os.close(tmp_fd)
+        with zipfile.ZipFile(
+            tmp_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+        ) as out_zf:
+            for arc_name, data, _ in kept:
+                out_zf.writestr(arc_name, data)
+
+        bytes_before = source.stat().st_size
+        bytes_after = tmp_path.stat().st_size
+        saved = bytes_before - bytes_after
+
+        # SAFE_003: report max-compression result
+        if saved > 0:
+            changes.append(
+                ChangeEntry(
+                    transform_id="SAFE_003",
+                    status="applied",
+                    detail="Repacked with maximum compression",
+                    bytes_saved=saved,
+                )
+            )
+        else:
+            changes.append(
+                ChangeEntry(
+                    transform_id="SAFE_003",
+                    status="skipped",
+                    detail="Maximum compression did not reduce archive size",
+                )
+            )
+
+        os.replace(tmp_path, dest)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+    return changes

--- a/afterburner/optimize/safe_fixes.py
+++ b/afterburner/optimize/safe_fixes.py
@@ -1,0 +1,28 @@
+"""Safe, zero-risk transform predicates for .miz archive entries."""
+
+from __future__ import annotations
+
+import fnmatch
+
+# Entries matching any of these patterns are junk — safe to remove
+_JUNK_PATTERNS = (
+    "__MACOSX/*",
+    ".DS_Store",
+    "*/.DS_Store",
+    "Thumbs.db",
+    "*/Thumbs.db",
+    "desktop.ini",
+    "*/desktop.ini",
+    "~*.tmp",
+    "*~*.tmp",
+    "*.bak",
+)
+
+
+def is_junk(name: str) -> bool:
+    return any(fnmatch.fnmatch(name, pat) for pat in _JUNK_PATTERNS)
+
+
+def normalize_path(name: str) -> str:
+    """Normalize backslash separators to forward slashes."""
+    return name.replace("\\", "/")

--- a/afterburner/parsers/lua_table.py
+++ b/afterburner/parsers/lua_table.py
@@ -142,7 +142,7 @@ class _Parser:
             if next_c in ('"', "'"):
                 # ["key"] or ['key']
                 self._pos += 1  # skip [
-                key = self._parse_quoted_string()
+                key: str | int | float = self._parse_quoted_string()
                 self._skip()
                 if self._pos >= self._len or self._text[self._pos] != "]":
                     raise LuaParseError(

--- a/afterburner/reporters/markdown.py
+++ b/afterburner/reporters/markdown.py
@@ -1,0 +1,64 @@
+"""Markdown report output."""
+
+from __future__ import annotations
+
+from afterburner.models.findings import Severity
+from afterburner.models.report import Report
+
+_SEVERITY_EMOJI = {
+    Severity.CRITICAL: "🔴",
+    Severity.WARNING: "🟡",
+    Severity.INFO: "🔵",
+}
+
+
+def to_markdown(report: Report) -> str:
+    mission = report.mission
+    s = mission.summary
+    lines: list[str] = []
+
+    lines.append(f"# DCS Afterburner Report: {mission.name}")
+    lines.append("")
+    lines.append(f"**Source:** `{mission.source_file}`  ")
+    lines.append(f"**Hash:** `{mission.sha256}`  ")
+    lines.append(f"**Theatre:** {s.theatre}  ")
+    lines.append(f"**Risk:** {report.risk_score()}/100 — {report.risk_label()}")
+    lines.append("")
+
+    lines.append("## Mission Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Total units | {s.total_units} |")
+    lines.append(f"| Active at start | {s.active_units} |")
+    lines.append(f"| Late activation | {s.late_units} |")
+    lines.append(f"| Player slots | {s.player_slots} |")
+    lines.append(f"| Groups (total) | {s.total_groups} |")
+    lines.append(f"| Active groups | {s.active_groups} |")
+    lines.append(f"| Static objects | {s.total_statics} |")
+    lines.append(f"| Triggers | {s.trigger_count} |")
+    lines.append(f"| Trigger zones | {s.zone_count} |")
+    lines.append("")
+
+    if report.findings:
+        lines.append("## Findings")
+        lines.append("")
+        for f in report.findings:
+            icon = _SEVERITY_EMOJI.get(f.severity, "")
+            lines.append(f"### {icon} `{f.rule_id}` — {f.title}")
+            lines.append("")
+            lines.append(f"**Severity:** {f.severity.value}  ")
+            lines.append(f"**Confidence:** {f.confidence:.0%}  ")
+            lines.append("")
+            lines.append(f.detail)
+            if f.fix:
+                lines.append("")
+                lines.append(f"**Fix:** {f.fix}")
+            lines.append("")
+    else:
+        lines.append("## Findings")
+        lines.append("")
+        lines.append("No findings.")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/afterburner/rules/__init__.py
+++ b/afterburner/rules/__init__.py
@@ -1,0 +1,3 @@
+"""Rule registry — import all modules to trigger @register decorators."""
+
+from afterburner.rules import maintainability, mission_size, performance  # noqa: F401

--- a/afterburner/rules/base.py
+++ b/afterburner/rules/base.py
@@ -1,0 +1,36 @@
+"""Rule base class, registry, and runner."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from afterburner.models.findings import ReportFinding
+from afterburner.models.mission import Mission
+
+_log = logging.getLogger(__name__)
+
+_registry: list[type[Rule]] = []
+
+
+def register(cls: type[Rule]) -> type[Rule]:
+    _registry.append(cls)
+    return cls
+
+
+def run_all(mission: Mission) -> list[ReportFinding]:
+    findings: list[ReportFinding] = []
+    for rule_cls in _registry:
+        try:
+            findings.extend(rule_cls().check(mission))
+        except Exception:
+            _log.exception("Rule %s raised an unhandled exception", rule_cls.rule_id)
+    return findings
+
+
+class Rule(ABC):
+    rule_id: ClassVar[str]
+
+    @abstractmethod
+    def check(self, mission: Mission) -> list[ReportFinding]: ...

--- a/afterburner/rules/maintainability.py
+++ b/afterburner/rules/maintainability.py
@@ -1,0 +1,63 @@
+"""Maintainability rules (MAINT_*)."""
+
+from __future__ import annotations
+
+from afterburner.models.findings import ReportFinding, Severity
+from afterburner.models.mission import Mission
+from afterburner.rules.base import Rule, register
+
+_DEFAULT_PREFIXES = ("New ", "Static Object", "Vehicle", "Airplane", "Helicopter")
+
+
+@register
+class UnnamedGroups(Rule):
+    rule_id = "MAINT_001"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        all_groups = mission.groups + mission.statics
+        if not all_groups:
+            return []
+        unnamed = [
+            g
+            for g in all_groups
+            if not g.name or any(g.name.startswith(p) for p in _DEFAULT_PREFIXES)
+        ]
+        pct = len(unnamed) / len(all_groups)
+        if pct > 0.05:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.INFO,
+                    title="Many groups with default names",
+                    detail=f"{len(unnamed)} of {len(all_groups)} groups ({pct:.0%}) appear to use "
+                    "default DCS-generated names. This makes trigger/script maintenance harder.",
+                    fix="Rename groups to reflect their tactical purpose.",
+                )
+            ]
+        return []
+
+
+@register
+class DuplicateGroupNames(Rule):
+    rule_id = "MAINT_002"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        all_groups = mission.groups + mission.statics
+        seen: dict[str, int] = {}
+        for g in all_groups:
+            if g.name:
+                seen[g.name] = seen.get(g.name, 0) + 1
+        dupes = {name: count for name, count in seen.items() if count > 1}
+        if dupes:
+            examples = ", ".join(list(dupes)[:5])
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="Duplicate group names",
+                    detail=f"{len(dupes)} group names appear more than once (e.g. {examples}). "
+                    "DCS trigger conditions that match by name will fire on all groups with that name.",
+                    fix="Ensure every group has a unique name.",
+                )
+            ]
+        return []

--- a/afterburner/rules/mission_size.py
+++ b/afterburner/rules/mission_size.py
@@ -1,0 +1,148 @@
+"""Mission size / bloat rules (BLOT_*)."""
+
+from __future__ import annotations
+
+from afterburner.models.findings import ReportFinding, Severity
+from afterburner.models.mission import Mission
+from afterburner.rules.base import Rule, register
+
+
+@register
+class ActiveUnitCount(Rule):
+    rule_id = "BLOT_001"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        n = mission.summary.active_units
+        if n > 1000:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.CRITICAL,
+                    title="Excessive active units",
+                    detail=f"{n} units active at mission start (threshold: 1000). "
+                    "Expect severe FPS impact on entry-level servers.",
+                    fix="Move non-essential groups to late activation or delete them.",
+                )
+            ]
+        if n > 600:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="High active unit count",
+                    detail=f"{n} units active at mission start (threshold: 600). "
+                    "May cause performance issues on lower-end servers.",
+                    fix="Consider late-activating groups that spawn later in the mission.",
+                )
+            ]
+        return []
+
+
+@register
+class TotalUnitCount(Rule):
+    rule_id = "BLOT_008"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        n = mission.summary.total_units
+        if n > 1200:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="Very high total unit count",
+                    detail=f"{n} total units in mission (threshold: 1200). "
+                    "Even late-activated units consume memory.",
+                    fix="Audit late-activation groups and remove units not used by the mission flow.",
+                )
+            ]
+        return []
+
+
+@register
+class StaticObjectCount(Rule):
+    rule_id = "BLOT_002"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        n = mission.summary.total_statics
+        if n > 800:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.CRITICAL,
+                    title="Excessive static objects",
+                    detail=f"{n} static objects (threshold: 800). "
+                    "Statics are always active and are a major FPS cost.",
+                    fix="Remove decorative statics or replace dense clusters with scenery objects.",
+                )
+            ]
+        if n > 500:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="High static object count",
+                    detail=f"{n} static objects (threshold: 500).",
+                    fix="Review statics for decorative items that can be removed.",
+                )
+            ]
+        return []
+
+
+@register
+class TriggerCount(Rule):
+    rule_id = "BLOT_003"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        n = mission.summary.trigger_count
+        if n > 150:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="High trigger count",
+                    detail=f"{n} triggers (threshold: 150). "
+                    "Each trigger is evaluated every frame until it fires.",
+                    fix="Consolidate triggers or move logic to a Lua script using event handlers.",
+                )
+            ]
+        return []
+
+
+@register
+class ZoneCount(Rule):
+    rule_id = "BLOT_004"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        n = mission.summary.zone_count
+        if n > 100:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="High trigger zone count",
+                    detail=f"{n} trigger zones (threshold: 100). "
+                    "Zones used in triggers are evaluated every frame.",
+                    fix="Remove unused zones or merge overlapping zones.",
+                )
+            ]
+        return []
+
+
+@register
+class PlayerSlotCount(Rule):
+    rule_id = "BLOT_005"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        n = mission.summary.player_slots
+        if n > 80:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="Very high player slot count",
+                    detail=f"{n} player slots (threshold: 80). "
+                    "Excess slots waste group slots and can confuse server browsers.",
+                    fix="Remove unused player slots, especially duplicate airframes at the same base.",
+                )
+            ]
+        return []

--- a/afterburner/rules/performance.py
+++ b/afterburner/rules/performance.py
@@ -1,0 +1,33 @@
+"""Performance rules (PERF_*)."""
+
+from __future__ import annotations
+
+from afterburner.models.findings import ReportFinding, Severity
+from afterburner.models.mission import Category, Mission
+from afterburner.rules.base import Rule, register
+
+
+@register
+class UncontrolledAircraft(Rule):
+    rule_id = "PERF_003"
+
+    def check(self, mission: Mission) -> list[ReportFinding]:
+        air_categories = {Category.PLANE, Category.HELICOPTER}
+        uncontrolled = [
+            g
+            for g in mission.groups
+            if g.category in air_categories and g.uncontrolled and not g.late_activation
+        ]
+        n = len(uncontrolled)
+        if n > 10:
+            return [
+                ReportFinding(
+                    rule_id=self.rule_id,
+                    severity=Severity.WARNING,
+                    title="Many uncontrolled active aircraft",
+                    detail=f"{n} uncontrolled air groups are active at mission start. "
+                    "Uncontrolled aircraft still load AI pathfinding and consume CPU.",
+                    fix="Late-activate uncontrolled aircraft or remove groups not needed at start.",
+                )
+            ]
+        return []

--- a/docs/dcs-linting.md
+++ b/docs/dcs-linting.md
@@ -1,0 +1,345 @@
+DCS Lua Linting & Benchmarking Pipeline
+Overview
+
+This project defines a GitHub Actions–based pipeline for validating and analyzing Lua scripts used in Digital Combat Simulator (DCS).
+
+The goal is to move beyond generic Lua linting and implement:
+
+A DCS-aware linter
+A framework-aware analyzer (MOOSE, MIST, etc.)
+A repeatable benchmarking system to track performance and regressions
+
+DCS uses Lua 5.1, and its scripting environment introduces non-standard globals, timing constraints, and runtime behaviors that require specialized validation.
+
+Core Objectives
+1. Linting
+Enforce correct Lua syntax
+Detect DCS-specific scripting issues
+Prevent common mission-breaking patterns
+2. Static Analysis
+Understand usage of:
+DCS API
+MOOSE
+MIST
+Validate function usage and patterns
+3. Benchmarking
+Measure performance of:
+Linting pipeline
+Parser and rule engine
+Detect regressions over time
+DCS Scripting Environment
+Known Global Tables & Singletons
+
+These are implicitly available in DCS and must be whitelisted:
+
+world
+coalition
+timer
+net
+trigger
+Unit
+Weapon
+StaticObject
+Airbase
+Access Patterns
+
+DCS uses function-based access instead of direct variable access:
+
+coalition.getPlayers()
+Unit.getByName("unitName")
+Object.inAir(unit)
+Object.getVelocity(unit)
+Important Constraints
+Global Scope Behavior
+Variables without local are global and persist across triggers
+This can cause cross-script contamination
+Timing Issues
+Objects may not exist at script execution time
+Late activation is common
+Must use timer.scheduleFunction when needed
+Performance Constraints
+Blocking loops can freeze the simulation
+All long-running logic must be scheduled
+Linting Architecture
+Base Linter
+
+Use:
+
+luacheck as the baseline static analyzer
+
+Configuration:
+
+Add DCS globals to avoid false positives
+Enforce strict global usage rules
+Custom DCS Rule Engine
+
+A secondary linter layer will enforce domain-specific rules.
+
+Rule Categories
+1. Unsafe Global Writes
+myVar = 5
+
+Problem:
+
+Creates persistent global state unintentionally
+
+Rule:
+
+Require explicit opt-in or enforce local
+2. Unsafe Object Access
+Unit.getByName("Aerial-1"):getPoint()
+
+Problem:
+
+Object may be nil
+
+Correct Pattern:
+
+local u = Unit.getByName("Aerial-1")
+if u then
+  u:getPoint()
+end
+3. Timing Violations
+
+Flag:
+
+Direct access to late-activated units
+Immediate execution assumptions
+
+Recommend:
+
+Use timer.scheduleFunction
+4. Blocking Execution
+while true do
+
+Problem:
+
+Freezes DCS engine
+
+Rule:
+
+Require scheduled execution model
+5. Event Handler Validation
+
+Validate correct usage of:
+
+world.addEventHandler(handler)
+
+Ensure:
+
+Proper event structure
+Valid handler definitions
+Framework Awareness
+Supported Frameworks
+MOOSE
+MIST
+CTLD (planned)
+Skynet IADS (planned)
+API Extraction System
+Goal
+
+Extract function signatures into JSON for:
+
+Validation
+Autocomplete
+Static analysis
+Example Output
+{
+  "MOOSE": {
+    "SPAWN:New": ["string"],
+    "SPAWN:Spawn": []
+  },
+  "mist": {
+    "mist.scheduleFunction": ["function", "table", "number"]
+  }
+}
+Implementation Strategy
+Step 1: Parse Source Trees
+
+Paths:
+
+~/Documents/Projects/MOOSE
+~/Documents/Projects/MissionScriptingTools
+
+Extract:
+
+Function names
+Method chains
+Basic argument patterns
+Step 2: Normalize Output
+
+Flatten into:
+
+Callable names
+Expected argument counts/types (best effort)
+Step 3: Use in Linter
+
+Validate:
+
+Function existence
+Basic usage patterns
+Limitations
+Cannot fully resolve:
+Metatables
+Dynamic inheritance
+Must supplement with manual rules
+Benchmarking System
+Purpose
+
+Track performance of:
+
+Linter
+Parser
+Rule engine
+
+Detect:
+
+Regressions
+Scaling issues
+Benchmark Scope
+1. Linter Performance
+
+Measure:
+
+Total runtime
+Time per file
+Time per corpus size
+2. Parser Performance
+
+Measure:
+
+Time to process MOOSE
+Time to process MIST
+JSON generation cost
+3. Rule Engine Cost
+
+Measure:
+
+Time per rule
+Identify expensive checks
+Benchmark Corpus
+bench/
+  corpus/
+    small/
+    medium/
+    large/
+Definitions
+small: utility scripts
+medium: typical mission scripts
+large: full mission packages
+Benchmark Tooling
+
+Use:
+
+hyperfine for repeatable benchmarking
+
+Capabilities:
+
+Warmup runs
+Multiple iterations
+Statistical output
+Export formats (JSON, Markdown)
+GitHub Actions Plan
+Workflow 1: Linting (ci-lint.yml)
+
+Triggers:
+
+push
+pull_request
+
+Purpose:
+
+Fast validation
+Blocking errors
+Jobs
+1. LuaCheck
+- run: luacheck .
+2. DCS Linter
+- run: ./tools/dcs-lint .
+Workflow 2: Benchmarking (benchmark.yml)
+
+Triggers:
+
+manual (workflow_dispatch)
+scheduled (weekly)
+Job: Benchmark
+name: benchmark
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hyperfine
+
+      - name: Run benchmarks
+        run: |
+          mkdir -p bench-out
+
+          hyperfine --warmup 3 --runs 10 \
+            './tools/dcs-lint bench/corpus/small' \
+            './tools/dcs-lint bench/corpus/medium' \
+            './tools/dcs-lint bench/corpus/large' \
+            --export-json bench-out/results.json \
+            --export-markdown bench-out/results.md
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: bench-out/
+Benchmark Policy
+Do NOT fail builds for small regressions
+
+Instead:
+
+Track trends
+Flag major regressions (>25–50%)
+Runner Strategy
+GitHub-hosted runners
+Good for general benchmarking
+Not reliable for micro-optimizations
+Self-hosted runners (recommended later)
+Stable environment
+Better for long-term tracking
+Future Enhancements
+1. Pattern Cost Benchmarks
+
+Test:
+
+repeated Unit.getByName
+table allocation
+string concatenation
+event dispatch patterns
+2. Rule Severity Levels
+Error (fail CI)
+Warning
+Info
+3. Incremental Linting
+Only analyze changed files
+4. Cached Symbol Index
+Avoid regenerating MOOSE/MIST index each run
+Summary
+
+This system provides:
+
+A DCS-aware linting pipeline
+A framework-aware validation layer
+A repeatable benchmarking system
+
+Key design decisions:
+
+Separate linting and benchmarking
+Focus on high-value DCS-specific rules
+Use static extraction for framework awareness
+Avoid over-reliance on runtime assumptions

--- a/docs/dcs-release.md
+++ b/docs/dcs-release.md
@@ -1,0 +1,224 @@
+keep the mission source in normal folders in the repo,
+have a build job assemble those files into the expected mission package layout,
+zip that layout into a .miz,
+upload it as a workflow artifact, and optionally
+publish it as a GitHub release asset. GitHub Actions supports manual triggers with workflow_dispatch, passing files between jobs with artifacts, and attaching built files to releases.
+Practical structure
+
+A solid repo layout would be something like:
+
+mission-src/
+  Init/
+  Scripts/
+  Moose/
+  Mist/
+  CTLD/
+  l10n/
+  options/
+build/
+tools/
+.github/workflows/
+
+Then the pipeline builds:
+
+dist/MyMission-v1.2.3.miz
+The important caveat
+
+This only works cleanly if you define a source-of-truth build layout.
+
+For DCS missions, the safest pattern is usually:
+
+keep a known-good base mission package or extracted mission folder,
+replace or inject the generated Lua/scripts during CI,
+then rebuild the .miz.
+
+That avoids trying to regenerate every mission-side file from scratch and accidentally producing a package that is syntactically valid as a zip but wrong for DCS.
+
+Best pipeline design
+
+I would split it into three workflows or three jobs in one workflow.
+
+1. Validate
+
+Runs on push and pull request.
+
+It should:
+
+lint Lua
+run your custom DCS checks
+optionally run benchmark-lite on the linter itself
+2. Build mission package
+
+Runs on tag push or manual dispatch.
+
+It should:
+
+check out the repo
+stage a clean build directory
+copy the base mission contents
+inject updated scripts
+generate version metadata
+package everything into .miz
+upload the .miz as an artifact
+
+Artifacts are the right way to persist the built package from the workflow.
+
+3. Release
+
+Runs on tags, or after a successful build job.
+
+It should:
+
+download the built .miz artifact
+create or update a GitHub release
+attach the .miz file to that release
+
+GitHub’s release flow and release asset upload API support exactly that pattern.
+
+What I would actually build
+
+Use a manual-and-tag-driven release workflow.
+
+Trigger it with:
+
+workflow_dispatch for test builds
+push.tags for actual release builds
+
+That gives you:
+
+test packaging on demand
+stable release packaging on version tags
+
+GitHub documents workflow_dispatch for manual runs, and workflows can be configured around those triggers.
+
+Recommended build logic
+
+Your builder script should do this in order:
+
+1. Clean dist/ and tmp/
+2. Copy base mission template to tmp/mission/
+3. Copy repo-managed Lua/scripts into tmp/mission/
+4. Inject version/build info
+5. Validate required files exist
+6. Package tmp/mission/ into dist/<name>.miz
+7. Emit checksum
+
+That validation step matters. The build should fail if required files are missing, duplicated, or placed in the wrong path.
+
+Best way to manage the source mission
+
+You have two realistic options.
+
+Option A — Store an extracted mission tree in git
+
+This is best if:
+
+multiple files are changing regularly
+you want diffable content
+you want CI to assemble the package from readable sources
+
+This is usually the better long-term choice.
+
+Option B — Store a base .miz and patch it during CI
+
+This is best if:
+
+only a few Lua files change
+the rest of the mission structure is mostly static
+
+This is simpler at first, but worse for maintenance if the mission grows.
+
+For your use case, with linting and planned static analysis, Option A is better.
+
+Release naming
+
+Use deterministic names, for example:
+
+Goonfront-Caucasus-v1.4.0.miz
+Goonfront-Caucasus-main+sha-abc1234.miz
+
+That makes artifacts and releases much easier to track.
+
+Good extra outputs
+
+Have the workflow also generate:
+
+SHA256 checksum
+build manifest
+release notes stub
+lint summary
+
+Then upload all of them as artifacts, and optionally include them in the release. GitHub artifacts are designed for storing files produced by a workflow.
+
+Good failure gates
+
+The build job should stop if:
+
+lint fails
+required mission files are missing
+duplicate injected scripts are found
+package output is empty or unusually small
+version tag and embedded version disagree
+
+That keeps “bad but zipped” missions from being published.
+
+Example workflow skeleton
+name: build-miz
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare build dirs
+        run: |
+          rm -rf dist tmp
+          mkdir -p dist tmp/mission
+
+      - name: Stage mission files
+        run: |
+          cp -R mission-base/* tmp/mission/
+          cp -R mission-src/* tmp/mission/
+
+      - name: Validate mission layout
+        run: |
+          test -f tmp/mission/mission
+          test -d tmp/mission/Scripts
+
+      - name: Build miz
+        run: |
+          cd tmp/mission
+          zip -r ../../dist/Goonfront-Caucasus-${GITHUB_REF_NAME:-dev}.miz .
+
+      - name: Checksum
+        run: |
+          sha256sum dist/*.miz > dist/SHA256SUMS.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: miz-build
+          path: dist/
+
+Then a release job can either call the GitHub API or use a release action to attach the .miz artifact to a release. GitHub supports both release creation and asset upload for built files.
+
+Where this fits in your broader plan
+
+Your full CI/CD stack can be:
+
+ci-lint.yml → Lua lint + DCS rules
+benchmark.yml → parser/linter performance tracking
+build-miz.yml → assemble mission package
+release.yml → publish tagged .miz
+
+That is a solid progression:
+validate first, package second, publish last.

--- a/docs/lualinter.md
+++ b/docs/lualinter.md
@@ -1,0 +1,51 @@
+DCS uses Lua version 5.1
+
+starting point:
+https://github.com/mpeterv/luacheck
+
+We are going to make a Github Action that checks lua on ingest against known DCS world practices.
+
+DCS Global Variables:
+
+Here are the key, known global tables and singleton objects available in the DCS scripting environment:
+Key Global Tables & Singletons
+
+    world: The main singleton for interacting with the game world, used to manage events and query world data.
+    coalition: Provides functions to manage coalitions and query data about sides (red/blue).
+    timer: Essential for scheduling actions or delaying function calls, as standard Lua loops can freeze the game.
+    net: Provides networking information, crucial for multiplayer missions.
+    trigger: Allows the script to interact with mission editor triggers, including displaying messages and triggering actions.
+    Unit / Weapon / StaticObject / Airbase: Classes used to interact with specific object types in the simulation. 
+
+Accessing Data via Functions
+Since true pre-defined variables are rare, you must call functions to get data: 
+
+    coalition.getPlayers(): Returns a table of all active players in the mission.
+    Unit.getByName('name'): Gets a unit object based on the name assigned in the Mission Editor.
+    Object.inAir(object): Returns true if the specified unit is currently airborne.
+    Object.getVelocity(object): Returns the velocity vector of an object. 
+
+Important Notes on Scope
+
+    Persistent Globals: By default, any variable defined in a DO SCRIPT trigger without the local keyword is global and persists throughout the session across different triggers.
+    Local Variables: If you use local, the variable only exists within that specific DO SCRIPT container.
+    Timing Issues: Variables declared in a trigger might fail if the object they reference (like a late-activated aircraft) does not exist when the script runs. Using timer to delay script execution can solve this. 
+
+For specialized data, developers often use tools like DCS-BIOS for cockpit exports or MOOSE/MIST frameworks which provide higher-level wrapper functions for these native DCS global objects. 
+
+
+https://wiki.hoggitworld.com/view/Simulator_Scripting_Engine_Documentation
+
+https://flightcontrol-master.github.io/MOOSE_DOCS_DEVELOP/Documentation/DCS.html
+
+
+I have a clone of the moose github at ~Documents/Projects/MOOSE
+I also have Mist clone at ~Documents/Projects/MissionScriptingTools
+
+moose has linting tools in the github actions.
+
+could be good for the linting.  
+
+could we parse moose, mist and any other standard lua that we use into a json just the calls?  would thar be worth it?  Are there any other resources that I haven't found?
+
+

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,311 @@
+"""Tests for the safe optimization engine."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from afterburner.optimize.engine import run_safe_optimizations
+from afterburner.optimize.rewrite import repack_optimized
+from afterburner.optimize.safe_fixes import is_junk, normalize_path
+
+_MISSION_LUA = """\
+mission =
+{
+["theatre"] =
+"Caucasus",
+["sortie"] =
+"Optimize Test",
+["coalition"] =
+{
+},
+["triggers"] =
+{
+},
+["trig"] =
+{
+},
+}
+"""
+
+
+def _make_miz(path: Path, extra_entries: dict[str, bytes] | None = None) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mission", _MISSION_LUA)
+        zf.writestr("options", "options =\n{\n}\n")
+        zf.writestr("dictionary", "dictionary =\n{\n}\n")
+        zf.writestr("l10n/DEFAULT/dictionary", "dictionary =\n{\n}\n")
+        if extra_entries:
+            for name, data in extra_entries.items():
+                zf.writestr(name, data)
+
+
+# ------------------------------------------------------------------
+# safe_fixes unit tests
+# ------------------------------------------------------------------
+
+
+def test_is_junk_ds_store():
+    assert is_junk(".DS_Store")
+
+
+def test_is_junk_macosx():
+    assert is_junk("__MACOSX/mission")
+
+
+def test_is_junk_nested_ds_store():
+    assert is_junk("Scripts/.DS_Store")
+
+
+def test_is_junk_thumbs():
+    assert is_junk("Thumbs.db")
+
+
+def test_is_junk_desktop_ini():
+    assert is_junk("desktop.ini")
+
+
+def test_is_junk_tmp():
+    assert is_junk("~temp.tmp")
+
+
+def test_not_junk_mission():
+    assert not is_junk("mission")
+
+
+def test_not_junk_lua():
+    assert not is_junk("l10n/DEFAULT/dictionary")
+
+
+def test_normalize_path_backslash():
+    assert normalize_path("Scripts\\myscript.lua") == "Scripts/myscript.lua"
+
+
+def test_normalize_path_no_change():
+    assert normalize_path("Scripts/myscript.lua") == "Scripts/myscript.lua"
+
+
+# ------------------------------------------------------------------
+# repack_optimized
+# ------------------------------------------------------------------
+
+
+def test_repack_produces_valid_zip(tmp_path):
+    src = tmp_path / "source.miz"
+    dest = tmp_path / "dest.miz"
+    _make_miz(src)
+    repack_optimized(src, dest)
+    assert dest.exists()
+    assert zipfile.is_zipfile(dest)
+
+
+def test_repack_mission_entry_first(tmp_path):
+    src = tmp_path / "source.miz"
+    dest = tmp_path / "dest.miz"
+    _make_miz(src)
+    repack_optimized(src, dest)
+    with zipfile.ZipFile(dest, "r") as zf:
+        assert zf.namelist()[0] == "mission"
+
+
+def test_repack_round_trip_parse(tmp_path):
+    """Output must be parseable by the mission parser."""
+    from afterburner.parsers.mission_parser import parse
+
+    src = tmp_path / "source.miz"
+    dest = tmp_path / "dest.miz"
+    _make_miz(src)
+    repack_optimized(src, dest)
+    m = parse(dest)
+    assert m.theatre == "Caucasus"
+
+
+def test_repack_removes_junk(tmp_path):
+    src = tmp_path / "source.miz"
+    dest = tmp_path / "dest.miz"
+    _make_miz(
+        src,
+        extra_entries={
+            ".DS_Store": b"junk",
+            "__MACOSX/mission": b"junk",
+        },
+    )
+    changes = repack_optimized(src, dest)
+    applied_ids = [c.transform_id for c in changes if c.status == "applied"]
+    assert "SAFE_001" in applied_ids
+
+    with zipfile.ZipFile(dest, "r") as zf:
+        names = zf.namelist()
+    assert ".DS_Store" not in names
+    assert "__MACOSX/mission" not in names
+
+
+def test_repack_normalizes_backslash_paths(tmp_path):
+    src = tmp_path / "source.miz"
+    dest = tmp_path / "dest.miz"
+
+    with zipfile.ZipFile(src, "w") as zf:
+        zf.writestr("mission", _MISSION_LUA)
+        zf.writestr("Scripts\\myscript.lua", "-- script")
+
+    changes = repack_optimized(src, dest)
+    applied_ids = [c.transform_id for c in changes if c.status == "applied"]
+    assert "SAFE_002" in applied_ids
+
+    with zipfile.ZipFile(dest, "r") as zf:
+        names = zf.namelist()
+    assert "Scripts/myscript.lua" in names
+    assert "Scripts\\myscript.lua" not in names
+
+
+def test_repack_no_partial_on_failure(tmp_path):
+    """If output path is a directory, repack raises and leaves no partial file."""
+    src = tmp_path / "source.miz"
+    dest = tmp_path / "dest.miz"
+    dest.mkdir()  # make dest a directory so ZipFile write fails
+
+    _make_miz(src)
+    with pytest.raises(Exception):
+        repack_optimized(src, dest)
+
+
+# ------------------------------------------------------------------
+# run_safe_optimizations (engine)
+# ------------------------------------------------------------------
+
+
+def test_engine_creates_output(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = run_safe_optimizations(src)
+    assert result.output.exists()
+    assert result.output.name == "mission.optimized.miz"
+
+
+def test_engine_creates_backup(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = run_safe_optimizations(src)
+    assert result.backup.exists()
+    assert result.backup.name == "mission.miz.bak"
+
+
+def test_engine_backup_matches_original(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    original_bytes = src.read_bytes()
+    result = run_safe_optimizations(src)
+    assert result.backup.read_bytes() == original_bytes
+
+
+def test_engine_output_is_valid_miz(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = run_safe_optimizations(src)
+    assert zipfile.is_zipfile(result.output)
+
+
+def test_engine_output_round_trips(tmp_path):
+    from afterburner.parsers.mission_parser import parse
+
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = run_safe_optimizations(src)
+    m = parse(result.output)
+    assert m.name == "Optimize Test"
+
+
+def test_engine_custom_output_path(tmp_path):
+    src = tmp_path / "mission.miz"
+    out = tmp_path / "custom_output.miz"
+    _make_miz(src)
+    result = run_safe_optimizations(src, output=out)
+    assert result.output == out.resolve()
+
+
+def test_engine_rejects_same_path(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    with pytest.raises(ValueError, match="same as input"):
+        run_safe_optimizations(src, output=src)
+
+
+def test_engine_rejects_existing_output(tmp_path):
+    src = tmp_path / "mission.miz"
+    out = tmp_path / "existing.miz"
+    _make_miz(src)
+    out.write_bytes(b"existing")
+    with pytest.raises(FileExistsError):
+        run_safe_optimizations(src, output=out)
+
+
+def test_engine_removes_junk_entries(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src, extra_entries={".DS_Store": b"x", "Thumbs.db": b"y"})
+    result = run_safe_optimizations(src)
+    safe001 = [c for c in result.changes if c.transform_id == "SAFE_001"]
+    assert len(safe001) == 2
+
+
+def test_engine_bytes_before_after(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = run_safe_optimizations(src)
+    assert result.bytes_before > 0
+    assert result.bytes_after > 0
+    assert result.bytes_before == src.stat().st_size
+
+
+# ------------------------------------------------------------------
+# CLI integration
+# ------------------------------------------------------------------
+
+
+def test_cli_optimize_requires_safe(tmp_path):
+    from typer.testing import CliRunner
+
+    from afterburner.cli import app
+
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = CliRunner().invoke(app, ["optimize", str(src)])
+    assert result.exit_code == 2
+
+
+def test_cli_optimize_safe_flag(tmp_path):
+    from typer.testing import CliRunner
+
+    from afterburner.cli import app
+
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = CliRunner().invoke(app, ["optimize", str(src), "--safe"])
+    assert result.exit_code == 0
+    assert (tmp_path / "mission.optimized.miz").exists()
+
+
+def test_cli_optimize_json_output(tmp_path):
+    import json
+
+    from typer.testing import CliRunner
+
+    from afterburner.cli import app
+
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    result = CliRunner().invoke(app, ["optimize", str(src), "--safe", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    for key in ("source", "output", "backup", "bytes_before", "bytes_after", "changes"):
+        assert key in data
+
+
+def test_cli_optimize_missing_file(tmp_path):
+    from typer.testing import CliRunner
+
+    from afterburner.cli import app
+
+    result = CliRunner().invoke(app, ["optimize", str(tmp_path / "nope.miz"), "--safe"])
+    assert result.exit_code != 0

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,315 @@
+"""Tests for the rule engine — builds Mission objects directly."""
+
+from __future__ import annotations
+
+import afterburner.rules  # noqa: F401 — register all rules
+from afterburner.models.findings import Severity
+from afterburner.models.mission import (
+    Category,
+    Group,
+    Mission,
+    MissionSummary,
+    Unit,
+)
+from afterburner.models.report import Report
+
+
+def _make_summary(**kwargs) -> MissionSummary:
+    defaults = dict(
+        theatre="Caucasus",
+        total_units=0,
+        active_units=0,
+        late_units=0,
+        player_slots=0,
+        total_groups=0,
+        active_groups=0,
+        total_statics=0,
+        trigger_count=0,
+        zone_count=0,
+    )
+    defaults.update(kwargs)
+    return MissionSummary(**defaults)
+
+
+def _make_mission(summary: MissionSummary | None = None, **kwargs) -> Mission:
+    return Mission(
+        name="Test",
+        source_file="test.miz",
+        sha256="sha256:abc",
+        theatre="Caucasus",
+        summary=summary or _make_summary(),
+        **kwargs,
+    )
+
+
+def _unit(uid: int = 1, name: str = "Unit1", skill: str = "High") -> Unit:
+    return Unit(
+        id=uid,
+        name=name,
+        type="F-16C_50",
+        skill=skill,
+        late_activation=False,
+        x=0.0,
+        y=0.0,
+        is_player_slot=skill in ("Client", "Player"),
+    )
+
+
+def _group(
+    gid: int = 1,
+    name: str = "Group1",
+    category: Category = Category.PLANE,
+    coalition: str = "blue",
+    units: list[Unit] | None = None,
+    late_activation: bool = False,
+    uncontrolled: bool = False,
+) -> Group:
+    return Group(
+        id=gid,
+        name=name,
+        category=category,
+        coalition=coalition,
+        units=units or [_unit()],
+        late_activation=late_activation,
+        uncontrolled=uncontrolled,
+    )
+
+
+# ------------------------------------------------------------------
+# Report / risk scoring
+# ------------------------------------------------------------------
+
+
+def test_risk_score_no_findings():
+    report = Report(mission=_make_mission())
+    assert report.risk_score() == 100
+    assert report.risk_label() == "LOW"
+
+
+def test_risk_score_critical():
+    from afterburner.models.findings import ReportFinding
+
+    report = Report(
+        mission=_make_mission(),
+        findings=[ReportFinding("X", Severity.CRITICAL, "t", "d")],
+    )
+    assert report.risk_score() == 85
+    assert report.risk_label() == "LOW"
+
+
+def test_risk_score_clamps_to_zero():
+    from afterburner.models.findings import ReportFinding
+
+    findings = [ReportFinding("X", Severity.CRITICAL, "t", "d")] * 10
+    report = Report(mission=_make_mission(), findings=findings)
+    assert report.risk_score() == 0
+    assert report.risk_label() == "CRITICAL"
+
+
+def test_risk_label_moderate():
+    from afterburner.models.findings import ReportFinding
+
+    findings = [ReportFinding("X", Severity.WARNING, "t", "d")] * 10
+    report = Report(mission=_make_mission(), findings=findings)
+    # 100 - 50 = 50 → MODERATE (≥50, <80)
+    assert report.risk_score() == 50
+    assert report.risk_label() == "MODERATE"
+
+
+# ------------------------------------------------------------------
+# BLOT_001 — active units
+# ------------------------------------------------------------------
+
+
+def test_blot001_no_finding_below_threshold():
+    from afterburner.rules.mission_size import ActiveUnitCount
+
+    m = _make_mission(_make_summary(active_units=500))
+    assert ActiveUnitCount().check(m) == []
+
+
+def test_blot001_warning_above_600():
+    from afterburner.rules.mission_size import ActiveUnitCount
+
+    m = _make_mission(_make_summary(active_units=700))
+    findings = ActiveUnitCount().check(m)
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+    assert findings[0].rule_id == "BLOT_001"
+
+
+def test_blot001_critical_above_1000():
+    from afterburner.rules.mission_size import ActiveUnitCount
+
+    m = _make_mission(_make_summary(active_units=1200))
+    findings = ActiveUnitCount().check(m)
+    assert findings[0].severity == Severity.CRITICAL
+
+
+# ------------------------------------------------------------------
+# BLOT_002 — statics
+# ------------------------------------------------------------------
+
+
+def test_blot002_warning_above_500():
+    from afterburner.rules.mission_size import StaticObjectCount
+
+    m = _make_mission(_make_summary(total_statics=600))
+    findings = StaticObjectCount().check(m)
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+
+
+def test_blot002_critical_above_800():
+    from afterburner.rules.mission_size import StaticObjectCount
+
+    m = _make_mission(_make_summary(total_statics=900))
+    assert StaticObjectCount().check(m)[0].severity == Severity.CRITICAL
+
+
+# ------------------------------------------------------------------
+# BLOT_003 — triggers
+# ------------------------------------------------------------------
+
+
+def test_blot003_warning_above_150():
+    from afterburner.rules.mission_size import TriggerCount
+
+    m = _make_mission(_make_summary(trigger_count=200))
+    assert TriggerCount().check(m)[0].severity == Severity.WARNING
+
+
+def test_blot003_no_finding_at_150():
+    from afterburner.rules.mission_size import TriggerCount
+
+    m = _make_mission(_make_summary(trigger_count=150))
+    assert TriggerCount().check(m) == []
+
+
+# ------------------------------------------------------------------
+# BLOT_004 — zones
+# ------------------------------------------------------------------
+
+
+def test_blot004_warning_above_100():
+    from afterburner.rules.mission_size import ZoneCount
+
+    m = _make_mission(_make_summary(zone_count=101))
+    assert ZoneCount().check(m)[0].severity == Severity.WARNING
+
+
+# ------------------------------------------------------------------
+# BLOT_005 — player slots
+# ------------------------------------------------------------------
+
+
+def test_blot005_warning_above_80():
+    from afterburner.rules.mission_size import PlayerSlotCount
+
+    m = _make_mission(_make_summary(player_slots=81))
+    assert PlayerSlotCount().check(m)[0].severity == Severity.WARNING
+
+
+# ------------------------------------------------------------------
+# BLOT_008 — total units
+# ------------------------------------------------------------------
+
+
+def test_blot008_warning_above_1200():
+    from afterburner.rules.mission_size import TotalUnitCount
+
+    m = _make_mission(_make_summary(total_units=1300))
+    assert TotalUnitCount().check(m)[0].severity == Severity.WARNING
+
+
+# ------------------------------------------------------------------
+# PERF_003 — uncontrolled aircraft
+# ------------------------------------------------------------------
+
+
+def test_perf003_no_finding_below_threshold():
+    from afterburner.rules.performance import UncontrolledAircraft
+
+    groups = [_group(gid=i, name=f"G{i}", uncontrolled=True) for i in range(10)]
+    m = _make_mission(groups=groups)
+    assert UncontrolledAircraft().check(m) == []
+
+
+def test_perf003_warning_above_10():
+    from afterburner.rules.performance import UncontrolledAircraft
+
+    groups = [_group(gid=i, name=f"G{i}", uncontrolled=True) for i in range(11)]
+    m = _make_mission(groups=groups)
+    assert UncontrolledAircraft().check(m)[0].severity == Severity.WARNING
+
+
+def test_perf003_ignores_late_activation():
+    from afterburner.rules.performance import UncontrolledAircraft
+
+    groups = [
+        _group(gid=i, name=f"G{i}", uncontrolled=True, late_activation=True)
+        for i in range(15)
+    ]
+    m = _make_mission(groups=groups)
+    assert UncontrolledAircraft().check(m) == []
+
+
+def test_perf003_ignores_ground_units():
+    from afterburner.rules.performance import UncontrolledAircraft
+
+    groups = [
+        _group(gid=i, name=f"G{i}", category=Category.VEHICLE, uncontrolled=True)
+        for i in range(15)
+    ]
+    m = _make_mission(groups=groups)
+    assert UncontrolledAircraft().check(m) == []
+
+
+# ------------------------------------------------------------------
+# MAINT_001 — unnamed groups
+# ------------------------------------------------------------------
+
+
+def test_maint001_no_finding_small_pct():
+    from afterburner.rules.maintainability import UnnamedGroups
+
+    groups = [_group(gid=i, name=f"Named{i}") for i in range(20)]
+    groups[0] = _group(gid=0, name="New untitled")  # 1/20 = 5%, not > 5%
+    m = _make_mission(groups=groups)
+    assert UnnamedGroups().check(m) == []
+
+
+def test_maint001_info_when_many_default_names():
+    from afterburner.rules.maintainability import UnnamedGroups
+
+    named = [_group(gid=i, name=f"Named{i}") for i in range(10)]
+    default_named = [_group(gid=100 + i, name="New untitled") for i in range(5)]
+    m = _make_mission(groups=named + default_named)
+    findings = UnnamedGroups().check(m)
+    assert findings[0].severity == Severity.INFO
+
+
+# ------------------------------------------------------------------
+# MAINT_002 — duplicate group names
+# ------------------------------------------------------------------
+
+
+def test_maint002_no_finding_unique_names():
+    from afterburner.rules.maintainability import DuplicateGroupNames
+
+    groups = [_group(gid=i, name=f"Unique{i}") for i in range(5)]
+    m = _make_mission(groups=groups)
+    assert DuplicateGroupNames().check(m) == []
+
+
+def test_maint002_warning_on_duplicates():
+    from afterburner.rules.maintainability import DuplicateGroupNames
+
+    groups = [
+        _group(gid=1, name="Alpha"),
+        _group(gid=2, name="Alpha"),
+        _group(gid=3, name="Bravo"),
+    ]
+    m = _make_mission(groups=groups)
+    findings = DuplicateGroupNames().check(m)
+    assert findings[0].severity == Severity.WARNING


### PR DESCRIPTION
## Summary

- **Rule engine** — base class, registry, `run_all` runner with per-rule exception isolation
- **Mission size rules** — BLOT_001/002/003/004/005/008 (active units, total units, statics, triggers, zones, player slots)
- **Performance rule** — PERF_003 (uncontrolled active aircraft at mission start)
- **Maintainability rules** — MAINT_001/002 (default-named groups, duplicate group names)
- **Report + findings models** — `ReportFinding` with severity/confidence, `Report` with 0–100 risk scoring
- **Optimize engine** — backup-first repack, atomic write via temp file rename, change log
- **Safe transforms** — SAFE_001 junk removal, SAFE_002 path normalization, SAFE_003 max compression
- **Markdown reporter** — mission summary table + findings with severity icons
- **Tests** — 52 passing across `test_rules.py` and `test_optimize.py`
- **Docs** — `dcs-linting.md`, `dcs-release.md`, `lualinter.md`

## Test plan

- [ ] CI passes (pytest + ruff)
- [ ] `afterburner rules list` shows all registered rules
- [ ] `afterburner report <mission.miz> --format md` produces markdown output
- [ ] `afterburner optimize <mission.miz> --safe` creates `.optimized.miz` and `.bak`