### PR TITLE
fix: security hardening — path traversal, backup overwrite, XSS

### DIFF
--- a/afterburner/optimize/engine.py
+++ b/afterburner/optimize/engine.py
@@ -59,6 +59,10 @@ def run_safe_optimizations(
 
     # Create backup before touching anything
     backup = miz_path.with_suffix(".miz.bak")
+    if backup.exists():
+        raise FileExistsError(
+            f"Backup already exists: {backup}. Remove it before optimizing again."
+        )
     shutil.copy2(miz_path, backup)
 
     bytes_before = miz_path.stat().st_size

--- a/afterburner/utils/miz.py
+++ b/afterburner/utils/miz.py
@@ -28,12 +28,15 @@ def extract(miz_path: str | Path, dest_dir: str | Path | None = None) -> Path:
         dest = Path(dest_dir)
         dest.mkdir(parents=True, exist_ok=True)
 
+    dest_resolved = dest.resolve()
     with zipfile.ZipFile(miz_path, "r") as zf:
         for entry in zf.infolist():
             # Skip any directory entries (shouldn't exist but be safe)
             if entry.filename.endswith("/"):
                 continue
-            out_path = dest / entry.filename
+            out_path = (dest / entry.filename).resolve()
+            if not out_path.is_relative_to(dest_resolved):
+                raise ValueError(f"Path traversal attempt in archive: {entry.filename}")
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_bytes(zf.read(entry.filename))
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -648,7 +648,8 @@ function esc(s) {
   return String(s ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }
 
 function renderResults(d) {
@@ -676,7 +677,7 @@ function renderResults(d) {
     : sorted.map(f => `
         <div class="finding">
           <div class="f-header">
-            <span class="f-sev ${f.severity}">${f.severity.toUpperCase()}</span>
+            <span class="f-sev ${esc(f.severity)}">${esc(f.severity).toUpperCase()}</span>
             <span class="f-id">${esc(f.rule_id)}</span>
             <span class="f-title">${esc(f.title)}</span>
           </div>

--- a/tests/test_miz_unpack.py
+++ b/tests/test_miz_unpack.py
@@ -130,6 +130,16 @@ def test_miz_editor_cleans_up_on_success(tmp_path):
     assert not captured_work_dir.exists()
 
 
+def test_extract_rejects_path_traversal(tmp_path):
+    miz = tmp_path / "evil.miz"
+    with zipfile.ZipFile(miz, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mission", _MISSION.decode())
+        zf.writestr("../../escape.txt", "pwned")
+    dest = tmp_path / "out"
+    with pytest.raises(ValueError, match="Path traversal"):
+        extract(miz, dest)
+
+
 def test_miz_editor_cleans_up_on_exception(tmp_path):
     miz = tmp_path / "test.miz"
     _make_miz(miz)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -302,6 +302,15 @@ def test_cli_optimize_json_output(tmp_path):
         assert key in data
 
 
+def test_engine_rejects_existing_backup(tmp_path):
+    src = tmp_path / "mission.miz"
+    _make_miz(src)
+    backup = tmp_path / "mission.miz.bak"
+    backup.write_bytes(b"old backup")
+    with pytest.raises(FileExistsError, match="Backup already exists"):
+        run_safe_optimizations(src)
+
+
 def test_cli_optimize_missing_file(tmp_path):
     from typer.testing import CliRunner
 


### PR DESCRIPTION
## Summary

- **Path traversal (CWE-22):** `utils/miz.py` now resolves each extracted path and rejects any entry whose resolved path escapes the destination directory. A crafted `.miz` with entries like `../../etc/cron.d/evil` would previously write outside the temp dir.
- **Backup overwrite:** `optimize/engine.py` now raises `FileExistsError` if a `.miz.bak` already exists before creating the backup, preventing silent destruction of the user's only recovery copy.
- **HTML attribute XSS (defense-in-depth):** `docs/index.html` — added `"` → `&quot;` to the `esc()` helper so it is safe in attribute context, and wrapped the `f.severity` class attribute value through `esc()`.

## Test plan

- [ ] `test_extract_rejects_path_traversal` — crafts a ZIP with a `../../escape.txt` entry and asserts `ValueError` is raised
- [ ] `test_engine_rejects_existing_backup` — pre-creates a `.miz.bak` and asserts `FileExistsError` is raised
- [ ] Full suite: `pytest` — 229 tests, all pass