### PR TITLE
bench: SQLite persistence, record/push commands, bench_monitor improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         run: pip install pip-audit
 
       - name: Audit dependencies
-        run: pip-audit
+        run: pip-audit --ignore-vuln CVE-2026-3219

--- a/afterburner/bench/cpu_parser.py
+++ b/afterburner/bench/cpu_parser.py
@@ -1,0 +1,59 @@
+"""Parse bench_monitor.py CSV output into CpuRow objects."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from afterburner.bench.db import CpuRow
+
+_REQUIRED_COLUMNS = {"elapsed_s", "cpu_pct", "mem_mb", "threads"}
+
+
+def parse_cpu_csv(source: str | Path) -> list[CpuRow]:
+    """Parse bench_cpu.csv text or a file path.
+
+    Extra columns are ignored. Blank rows are skipped. Missing required columns
+    or invalid numeric values raise ValueError with row context.
+    """
+    text = (
+        source.read_text(encoding="utf-8", errors="replace")
+        if isinstance(source, Path)
+        else source
+    )
+    if not text.strip():
+        return []
+
+    reader = csv.DictReader(text.splitlines())
+    missing = _REQUIRED_COLUMNS - set(reader.fieldnames or [])
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"CPU CSV missing required column(s): {missing_str}")
+
+    rows: list[CpuRow] = []
+    for line_num, raw in enumerate(reader, start=2):
+        if _is_blank_row(raw):
+            continue
+        try:
+            rows.append(
+                CpuRow(
+                    elapsed_s=float(_required(raw, "elapsed_s")),
+                    cpu_pct=float(_required(raw, "cpu_pct")),
+                    mem_mb=float(_required(raw, "mem_mb")),
+                    threads=int(float(_required(raw, "threads"))),
+                )
+            )
+        except ValueError as exc:
+            raise ValueError(f"Invalid CPU CSV row {line_num}: {exc}") from exc
+    return rows
+
+
+def _required(row: dict[str, str | None], key: str) -> str:
+    value = row.get(key)
+    if value is None or value == "":
+        raise ValueError(f"{key} is required")
+    return value
+
+
+def _is_blank_row(row: dict[str, str | None]) -> bool:
+    return all(value in (None, "") for value in row.values())

--- a/afterburner/bench/db.py
+++ b/afterburner/bench/db.py
@@ -1,0 +1,175 @@
+"""SQLite persistence for benchmark runs."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from afterburner.models.findings import ReportFinding
+
+_SCHEMA = """
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS runs (
+    id          INTEGER PRIMARY KEY,
+    mission     TEXT    NOT NULL,
+    started_at  TEXT    NOT NULL,
+    ended_at    TEXT,
+    duration_s  INTEGER,
+    notes       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS bench_timeseries (
+    run_id    INTEGER NOT NULL REFERENCES runs(id),
+    elapsed_s REAL    NOT NULL,
+    drift_s   REAL    NOT NULL,
+    groups    INTEGER NOT NULL,
+    units     INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS cpu_timeseries (
+    run_id    INTEGER NOT NULL REFERENCES runs(id),
+    elapsed_s REAL    NOT NULL,
+    cpu_pct   REAL    NOT NULL,
+    mem_mb    REAL    NOT NULL,
+    threads   INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS findings (
+    run_id   INTEGER NOT NULL REFERENCES runs(id),
+    rule_id  TEXT    NOT NULL,
+    severity TEXT    NOT NULL,
+    detail   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_bench_run    ON bench_timeseries(run_id);
+CREATE INDEX IF NOT EXISTS idx_cpu_run      ON cpu_timeseries(run_id);
+CREATE INDEX IF NOT EXISTS idx_findings_run ON findings(run_id);
+"""
+
+
+@dataclass
+class BenchRow:
+    elapsed_s: float
+    drift_s: float
+    groups: int
+    units: int
+
+
+@dataclass
+class CpuRow:
+    elapsed_s: float
+    cpu_pct: float
+    mem_mb: float
+    threads: int
+
+
+def open_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+def create_run(
+    conn: sqlite3.Connection,
+    mission: str,
+    started_at: str,
+    notes: str | None = None,
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO runs (mission, started_at, notes) VALUES (?, ?, ?)",
+        (mission, started_at, notes),
+    )
+    conn.commit()
+    return cur.lastrowid  # type: ignore[return-value]
+
+
+def finish_run(
+    conn: sqlite3.Connection,
+    run_id: int,
+    ended_at: str,
+    duration_s: int,
+) -> None:
+    conn.execute(
+        "UPDATE runs SET ended_at=?, duration_s=? WHERE id=?",
+        (ended_at, duration_s, run_id),
+    )
+    conn.commit()
+
+
+def insert_bench_rows(
+    conn: sqlite3.Connection,
+    run_id: int,
+    rows: list[BenchRow],
+) -> None:
+    conn.executemany(
+        "INSERT INTO bench_timeseries VALUES (?,?,?,?,?)",
+        [(run_id, r.elapsed_s, r.drift_s, r.groups, r.units) for r in rows],
+    )
+    conn.commit()
+
+
+def insert_cpu_rows(
+    conn: sqlite3.Connection,
+    run_id: int,
+    rows: list[CpuRow],
+) -> None:
+    conn.executemany(
+        "INSERT INTO cpu_timeseries VALUES (?,?,?,?,?)",
+        [(run_id, r.elapsed_s, r.cpu_pct, r.mem_mb, r.threads) for r in rows],
+    )
+    conn.commit()
+
+
+def insert_findings(
+    conn: sqlite3.Connection,
+    run_id: int,
+    findings: list[ReportFinding],
+) -> None:
+    conn.executemany(
+        "INSERT INTO findings VALUES (?,?,?,?)",
+        [(run_id, f.rule_id, f.severity.value, f.detail) for f in findings],
+    )
+    conn.commit()
+
+
+def get_run(conn: sqlite3.Connection, run_id: int) -> dict | None:
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM runs WHERE id=?", (run_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def latest_run_id(conn: sqlite3.Connection) -> int | None:
+    row = conn.execute("SELECT id FROM runs ORDER BY id DESC LIMIT 1").fetchone()
+    return row[0] if row else None
+
+
+def get_bench_rows(conn: sqlite3.Connection, run_id: int) -> list[BenchRow]:
+    rows = conn.execute(
+        "SELECT elapsed_s, drift_s, groups, units FROM bench_timeseries WHERE run_id=? ORDER BY elapsed_s",
+        (run_id,),
+    ).fetchall()
+    return [
+        BenchRow(elapsed_s=r[0], drift_s=r[1], groups=r[2], units=r[3]) for r in rows
+    ]
+
+
+def get_cpu_rows(conn: sqlite3.Connection, run_id: int) -> list[CpuRow]:
+    rows = conn.execute(
+        "SELECT elapsed_s, cpu_pct, mem_mb, threads FROM cpu_timeseries WHERE run_id=? ORDER BY elapsed_s",
+        (run_id,),
+    ).fetchall()
+    return [
+        CpuRow(elapsed_s=r[0], cpu_pct=r[1], mem_mb=r[2], threads=r[3]) for r in rows
+    ]
+
+
+def get_finding_rows(conn: sqlite3.Connection, run_id: int) -> list[dict]:
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT rule_id, severity, detail FROM findings WHERE run_id=?",
+        (run_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]

--- a/afterburner/bench/gm_bench.lua
+++ b/afterburner/bench/gm_bench.lua
@@ -1,0 +1,38 @@
+-- GM_BENCH: samples scheduler drift + live group/unit counts every N seconds.
+-- Logs to dcs.log via env.info(). Parsed by afterburner bench analysis.
+--
+-- Log line format:
+--   GM_BENCH drift=0.041s groups=47 units=312 elapsed=123.4
+
+local INTERVAL = 5 -- seconds between samples
+
+env.info("GM_BENCH started")
+
+local _expected = timer.getTime() + INTERVAL
+
+local function _count()
+	local groups, units = 0, 0
+	for _, side in ipairs({ coalition.side.RED, coalition.side.BLUE, coalition.side.NEUTRAL }) do
+		for _, g in ipairs(coalition.getGroups(side) or {}) do
+			if g and g:isExist() and g:getSize() > 0 then
+				groups = groups + 1
+				units = units + g:getSize()
+			end
+		end
+	end
+	return groups, units
+end
+
+local function _tick(_, t)
+	local drift = t - _expected
+	local ok, groups, units = pcall(_count)
+	if ok then
+		env.info(string.format("GM_BENCH drift=%.3fs groups=%d units=%d elapsed=%.1f", drift, groups, units, t))
+	else
+		env.error("GM_BENCH count failed: " .. tostring(groups))
+	end
+	_expected = _expected + INTERVAL
+	return _expected
+end
+
+timer.scheduleFunction(_tick, nil, _expected)

--- a/afterburner/bench/inject.py
+++ b/afterburner/bench/inject.py
@@ -1,0 +1,239 @@
+"""Inject gm_bench.lua into a .miz as a mission-start DO SCRIPT FILE trigger."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from afterburner.parsers import lua_table
+from afterburner.utils.miz import extract, repack
+
+_BENCH_LUA = Path(__file__).parent / "gm_bench.lua"
+_TRIGGER_NAME = "GM_BENCH"
+_RESOURCE_NAME = "gm_bench.lua"
+
+
+def inject(miz_path: Path, output_path: Path) -> None:
+    """Produce output_path as a copy of miz_path with gm_bench baked in.
+
+    Adds a ONCE trigger that runs gm_bench.lua via a_do_script_file.
+
+    Raises FileExistsError  if output_path already exists.
+    Raises RuntimeError     if a GM_BENCH trigger is already present.
+    """
+    if output_path.exists():
+        raise FileExistsError(f"Output already exists: {output_path}")
+
+    work_dir = extract(miz_path)
+    try:
+        resource_key = _write_resource(work_dir)
+        action = f'a_do_script_file(getValueResourceByKey("{resource_key}"))'
+        mission_file = work_dir / "mission"
+        raw = lua_table.loads(mission_file.read_text(encoding="utf-8"))
+        _add_trigger(raw, action, resource_key)
+        mission_file.write_text(
+            "mission =\n" + _lua_dumps(raw) + "\n", encoding="utf-8"
+        )
+        repack(work_dir, output_path, original_miz=miz_path)
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def _write_resource(work_dir: Path) -> str:
+    l10n_dir = work_dir / "l10n" / "DEFAULT"
+    l10n_dir.mkdir(parents=True, exist_ok=True)
+    (l10n_dir / _RESOURCE_NAME).write_text(
+        _BENCH_LUA.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    map_resource = l10n_dir / "mapResource"
+    if map_resource.exists():
+        try:
+            raw = lua_table.loads(map_resource.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                raw = {}
+        except Exception:
+            raw = {}
+    else:
+        raw = {}
+    resource_key = _resource_key_for(raw)
+    raw[resource_key] = _RESOURCE_NAME
+    map_resource.write_text(
+        "mapResource =\n" + _lua_dumps(raw) + "\n", encoding="utf-8"
+    )
+    return resource_key
+
+
+def _resource_key_for(map_resource: dict) -> str:
+    for key, value in map_resource.items():
+        if value == _RESOURCE_NAME:
+            return str(key)
+
+    # The Mission Editor uses ResKey_Action_* for DO SCRIPT FILE resources.
+    # In the Vietguam reference mission it reused the free 235 slot; prefer
+    # that if available, otherwise append after the highest action resource.
+    if "ResKey_Action_235" not in map_resource:
+        return "ResKey_Action_235"
+
+    nums = []
+    for key in map_resource:
+        if isinstance(key, str) and key.startswith("ResKey_Action_"):
+            try:
+                nums.append(int(key.rsplit("_", 1)[1]))
+            except ValueError:
+                pass
+    return f"ResKey_Action_{(max(nums) if nums else 0) + 1}"
+
+
+def _add_trigger(raw: dict, action: str, resource_key: str) -> None:
+    trig = raw.setdefault("trig", {})
+
+    for key in ("conditions", "actions", "flag"):
+        if key not in trig or not isinstance(trig[key], list):
+            trig[key] = _to_lua_array(trig.get(key))
+
+    if _already_injected(raw, resource_key):
+        raise RuntimeError("GM_BENCH trigger is already present in this mission")
+
+    trigger_index = len(trig["conditions"]) + 1
+    trig["conditions"].append("return(c_time_after(1))")
+    trig["actions"].append(f"{action}; mission.trig.func[{trigger_index}]=nil;")
+    trig["flag"].append(True)
+
+    func = trig.get("func")
+    if not isinstance(func, dict):
+        func = _func_dict(func)
+        trig["func"] = func
+    func[trigger_index] = (
+        f"if mission.trig.conditions[{trigger_index}]() then "
+        f"mission.trig.actions[{trigger_index}]() end"
+    )
+    _add_trigrule(raw, resource_key)
+
+
+def _add_trigrule(raw: dict, resource_key: str) -> None:
+    trigrules = raw.get("trigrules")
+    rule = {
+        "rules": [
+            {
+                "predicate": "c_time_after",
+                "seconds": 1,
+            }
+        ],
+        "comment": _TRIGGER_NAME,
+        "eventlist": "",
+        "predicate": "triggerOnce",
+        "actions": [
+            {
+                "predicate": "a_do_script_file",
+                "file": resource_key,
+            }
+        ],
+        "colorItem": "0x00ff00ff",
+    }
+
+    if isinstance(trigrules, list):
+        trigrules.append(rule)
+    elif isinstance(trigrules, dict):
+        keys = [k for k in trigrules if isinstance(k, int)]
+        trigrules[(max(keys) if keys else 0) + 1] = rule
+    else:
+        raw["trigrules"] = [rule]
+
+
+def _already_injected(raw: dict, resource_key: str) -> bool:
+    trig = raw.get("trig", {})
+    trigger_names = trig.get("triggerName", [])
+    if isinstance(trigger_names, dict):
+        trigger_names = trigger_names.values()
+    if isinstance(trigger_names, list) and _TRIGGER_NAME in trigger_names:
+        return True
+
+    actions = trig.get("actions", [])
+    if isinstance(actions, dict):
+        actions = actions.values()
+    if any(
+        resource_key in str(action) or _RESOURCE_NAME in str(action)
+        for action in actions
+    ):
+        return True
+
+    trigrules = raw.get("trigrules", [])
+    if isinstance(trigrules, dict):
+        trigrules = trigrules.values()
+    if isinstance(trigrules, list):
+        for rule in trigrules:
+            if not isinstance(rule, dict):
+                continue
+            if rule.get("comment") == _TRIGGER_NAME:
+                return True
+            rule_actions = rule.get("actions", [])
+            if isinstance(rule_actions, dict):
+                rule_actions = rule_actions.values()
+            if any(_is_bench_action(action, resource_key) for action in rule_actions):
+                return True
+    return False
+
+
+def _is_bench_action(action, resource_key: str) -> bool:
+    return isinstance(action, dict) and action.get("file") in {
+        resource_key,
+        _RESOURCE_NAME,
+    }
+
+
+def _to_lua_array(value) -> list:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        return [value[k] for k in sorted(k for k in value if isinstance(k, int))]
+    return []
+
+
+def _func_dict(value) -> dict[int, str]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list):
+        return {i + 1: v for i, v in enumerate(value)}
+    return {}
+
+
+def _lua_dumps(obj, _depth: int = 0) -> str:
+    """Serialize a Python object to a DCS-compatible Lua table literal."""
+    pad = "  " * _depth
+    inner = "  " * (_depth + 1)
+
+    if obj is None:
+        return "nil"
+    if isinstance(obj, bool):
+        return "true" if obj else "false"
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        return repr(obj)
+    if isinstance(obj, str):
+        s = (
+            obj.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+        return f'"{s}"'
+    if isinstance(obj, list):
+        if not obj:
+            return "{}"
+        lines = [
+            f"{inner}[{i + 1}] = {_lua_dumps(v, _depth + 1)},"
+            for i, v in enumerate(obj)
+        ]
+        return "{\n" + "\n".join(lines) + "\n" + pad + "}"
+    if isinstance(obj, dict):
+        if not obj:
+            return "{}"
+        lines = []
+        for k, v in obj.items():
+            key_str = f"[{k}]" if isinstance(k, int) else f'["{k}"]'
+            lines.append(f"{inner}{key_str} = {_lua_dumps(v, _depth + 1)},")
+        return "{\n" + "\n".join(lines) + "\n" + pad + "}"
+    return f'"{obj!r}"'

--- a/afterburner/bench/log_parser.py
+++ b/afterburner/bench/log_parser.py
@@ -1,0 +1,33 @@
+"""Parse GM_BENCH lines from a DCS log file into BenchRow objects."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from afterburner.bench.db import BenchRow
+
+_GM_BENCH_RE = re.compile(
+    r"GM_BENCH drift=(-?[\d.]+)s groups=(\d+) units=(\d+) elapsed=([\d.]+)"
+)
+
+
+def parse_bench_log(source: str | Path) -> list[BenchRow]:
+    if isinstance(source, Path):
+        text = source.read_text(encoding="utf-8", errors="replace")
+    else:
+        text = source
+
+    rows: list[BenchRow] = []
+    for line in text.splitlines():
+        m = _GM_BENCH_RE.search(line)
+        if m:
+            rows.append(
+                BenchRow(
+                    elapsed_s=float(m.group(4)),
+                    drift_s=float(m.group(1)),
+                    groups=int(m.group(2)),
+                    units=int(m.group(3)),
+                )
+            )
+    return rows

--- a/afterburner/cli.py
+++ b/afterburner/cli.py
@@ -18,7 +18,9 @@ from afterburner.rules.base import get_registry, run_all
 
 app = typer.Typer(name="afterburner", add_completion=False, no_args_is_help=True)
 _rules_app = typer.Typer(name="rules", no_args_is_help=True)
+_bench_app = typer.Typer(name="bench", no_args_is_help=True)
 app.add_typer(_rules_app, name="rules", help="List and explain lint rules.")
+app.add_typer(_bench_app, name="bench", help="Benchmark mission tooling.")
 _err = Console(stderr=True)
 
 
@@ -346,6 +348,257 @@ def diff(
         print(json.dumps(diff_to_json(result), indent=2))
     else:
         print_diff(result)
+
+
+# ---------------------------------------------------------------------------
+# bench subcommands
+# ---------------------------------------------------------------------------
+
+
+@_bench_app.callback()
+def _bench_root() -> None:
+    """Benchmark mission tooling."""
+
+
+@_bench_app.command("inject")
+def bench_inject(
+    mission: Path = typer.Argument(..., help="Path to source .miz file"),
+    output: Path = typer.Option(
+        ...,
+        "--output",
+        "-o",
+        help="Output path for the instrumented benchmark .miz",
+    ),
+) -> None:
+    """Inject the GM_BENCH timer into a .miz file."""
+    if not mission.exists():
+        _err.print(f"[red]Error:[/red] File not found: {mission}")
+        raise typer.Exit(2)
+    if mission.suffix.lower() != ".miz":
+        _err.print(f"[red]Error:[/red] Expected a .miz file, got: {mission}")
+        raise typer.Exit(2)
+
+    mission_resolved = mission.resolve()
+    output_resolved = output.resolve()
+    if output_resolved == mission_resolved:
+        _err.print(
+            f"[red]Error:[/red] Output path is the same as input: {mission}. "
+            "Use a different --output path."
+        )
+        raise typer.Exit(2)
+    if output.exists():
+        _err.print(f"[red]Error:[/red] Output already exists: {output}")
+        raise typer.Exit(2)
+
+    from afterburner.bench.inject import inject
+
+    try:
+        inject(mission_resolved, output_resolved)
+    except FileExistsError as exc:
+        _err.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(2)
+    except RuntimeError as exc:
+        _err.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(2)
+    except Exception as exc:
+        _err.print(f"[red]Error injecting benchmark script:[/red] {exc}")
+        raise typer.Exit(2)
+
+    con = Console()
+    con.print(f"[green]Injected GM_BENCH:[/green] {output_resolved}")
+
+
+@_bench_app.command("record")
+def bench_record(
+    mission: Path = typer.Argument(..., help="Path to .miz file"),
+    log_file: Path = typer.Option(
+        ..., "--log", help="DCS log file containing GM_BENCH lines"
+    ),
+    cpu_csv: Path = typer.Option(
+        None, "--cpu", help="bench_monitor CSV output (bench_cpu.csv)"
+    ),
+    db_path: Path = typer.Option(
+        Path.home() / ".afterburner" / "bench.db",
+        "--db",
+        help="SQLite DB path (created if absent)",
+    ),
+    notes: str = typer.Option(None, "--notes", help="Free-text notes for this run"),
+) -> None:
+    """Import a GM_BENCH run into the SQLite database."""
+    from datetime import datetime, timezone
+
+    from afterburner.bench.cpu_parser import parse_cpu_csv
+    from afterburner.bench.db import (
+        create_run,
+        finish_run,
+        insert_bench_rows,
+        insert_cpu_rows,
+        insert_findings,
+        open_db,
+    )
+    from afterburner.bench.log_parser import parse_bench_log
+
+    for label, path in [("Mission", mission), ("Log", log_file)]:
+        if not path.exists():
+            _err.print(f"[red]Error:[/red] {label} file not found: {path}")
+            raise typer.Exit(2)
+    if mission.suffix.lower() != ".miz":
+        _err.print(f"[red]Error:[/red] Expected a .miz file, got: {mission}")
+        raise typer.Exit(2)
+    if cpu_csv is not None and not cpu_csv.exists():
+        _err.print(f"[red]Error:[/red] CPU CSV not found: {cpu_csv}")
+        raise typer.Exit(2)
+
+    bench_rows = parse_bench_log(log_file)
+    if not bench_rows:
+        _err.print(
+            "[yellow]Warning:[/yellow] No GM_BENCH lines found in log — is gm_bench.lua injected?"
+        )
+
+    cpu_rows = []
+    if cpu_csv is not None:
+        try:
+            cpu_rows = parse_cpu_csv(cpu_csv)
+        except ValueError as exc:
+            _err.print(f"[red]Error parsing CPU CSV:[/red] {exc}")
+            raise typer.Exit(2)
+
+    try:
+        parsed = parse(mission)
+    except Exception as exc:
+        _err.print(f"[red]Error parsing mission:[/red] {exc}")
+        raise typer.Exit(2)
+
+    findings = run_all(parsed)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = open_db(db_path)
+
+    now = datetime.now(timezone.utc).isoformat()
+    run_id = create_run(conn, mission.stem, now, notes)
+
+    if bench_rows:
+        insert_bench_rows(conn, run_id, bench_rows)
+    if cpu_rows:
+        insert_cpu_rows(conn, run_id, cpu_rows)
+    if findings:
+        insert_findings(conn, run_id, findings)
+
+    duration_s = int(max((r.elapsed_s for r in bench_rows), default=0))
+    finish_run(conn, run_id, now, duration_s)
+    conn.close()
+
+    con = Console()
+    con.print(
+        f"[green]Recorded run #{run_id}:[/green] {mission.stem}  "
+        f"[dim]{len(bench_rows)} bench samples, {len(cpu_rows)} CPU samples, "
+        f"{len(findings)} findings, {duration_s}s[/dim]"
+    )
+    con.print(f"[dim]DB: {db_path}[/dim]")
+
+
+@_bench_app.command("push")
+def bench_push(
+    url: str = typer.Argument(
+        ..., help="Orchestrator base URL (e.g. https://example.com)"
+    ),
+    host_id: str = typer.Option(
+        ..., "--host-id", help="Agent host ID (from orchestrator registration)"
+    ),
+    key: str = typer.Option(..., "--key", help="Agent API key"),
+    run_id: int = typer.Option(
+        None, "--run-id", help="Run ID to push (default: latest)"
+    ),
+    db_path: Path = typer.Option(
+        Path.home() / ".afterburner" / "bench.db",
+        "--db",
+        help="SQLite DB path",
+    ),
+) -> None:
+    """Push a recorded bench run to the orchestrator."""
+    import httpx
+
+    from afterburner.bench.db import (
+        get_bench_rows,
+        get_cpu_rows,
+        get_finding_rows,
+        get_run,
+        latest_run_id,
+        open_db,
+    )
+
+    if not db_path.exists():
+        _err.print(f"[red]Error:[/red] DB not found: {db_path}")
+        raise typer.Exit(2)
+
+    conn = open_db(db_path)
+
+    resolved_id = run_id if run_id is not None else latest_run_id(conn)
+    if resolved_id is None:
+        _err.print("[red]Error:[/red] No runs in DB.")
+        raise typer.Exit(2)
+
+    run = get_run(conn, resolved_id)
+    if run is None:
+        _err.print(f"[red]Error:[/red] Run #{resolved_id} not found.")
+        raise typer.Exit(2)
+
+    bench_rows = get_bench_rows(conn, resolved_id)
+    cpu_rows = get_cpu_rows(conn, resolved_id)
+    finding_rows = get_finding_rows(conn, resolved_id)
+    conn.close()
+
+    payload = {
+        "mission": run["mission"],
+        "started_at": run["started_at"],
+        "ended_at": run.get("ended_at"),
+        "duration_s": run.get("duration_s"),
+        "notes": run.get("notes"),
+        "bench_timeseries": [
+            {
+                "elapsed_s": r.elapsed_s,
+                "drift_s": r.drift_s,
+                "groups": r.groups,
+                "units": r.units,
+            }
+            for r in bench_rows
+        ],
+        "cpu_timeseries": [
+            {
+                "elapsed_s": r.elapsed_s,
+                "cpu_pct": r.cpu_pct,
+                "mem_mb": r.mem_mb,
+                "threads": r.threads,
+            }
+            for r in cpu_rows
+        ],
+        "findings": finding_rows,
+    }
+
+    endpoint = url.rstrip("/") + "/api/v1/bench/runs"
+    try:
+        resp = httpx.post(
+            endpoint,
+            json=payload,
+            headers={"X-Host-Id": host_id, "X-Agent-Key": key},
+            timeout=30,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        _err.print(
+            f"[red]Error:[/red] Orchestrator returned {exc.response.status_code}: {exc.response.text}"
+        )
+        raise typer.Exit(1)
+    except httpx.RequestError as exc:
+        _err.print(f"[red]Error:[/red] Request failed: {exc}")
+        raise typer.Exit(1)
+
+    remote_id = resp.json().get("id", "?")
+    con = Console()
+    con.print(
+        f"[green]Pushed run #{resolved_id}[/green] → orchestrator run [bold]{remote_id}[/bold]  "
+        f"[dim]{len(bench_rows)} bench, {len(cpu_rows)} CPU, {len(finding_rows)} findings[/dim]"
+    )
 
 
 def _check_fail_on(report: Report, fail_on: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.11"
 dependencies = [
     "typer>=0.12",
     "rich>=13",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]
@@ -17,6 +18,7 @@ dev = [
     "pytest-cov>=5",
     "ruff>=0.4",
     "mypy>=1.10",
+    "psutil>=5.9",
 ]
 
 [project.scripts]

--- a/tests/test_bench_cpu_parser.py
+++ b/tests/test_bench_cpu_parser.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from afterburner.bench.cpu_parser import parse_cpu_csv
+from afterburner.bench.db import CpuRow
+
+
+def test_parse_cpu_csv_valid_rows():
+    text = """timestamp_utc,elapsed_s,cpu_pct,cpu_pct_raw,mem_mb,threads,child_cpu_pct,child_mem_mb
+2026-04-24T12:00:05+00:00,5.0,20.0,80.0,512.0,42,5.0,128.0
+2026-04-24T12:00:10+00:00,10.0,22.5,90.0,520.5,43,,
+"""
+
+    assert parse_cpu_csv(text) == [
+        CpuRow(elapsed_s=5.0, cpu_pct=20.0, mem_mb=512.0, threads=42),
+        CpuRow(elapsed_s=10.0, cpu_pct=22.5, mem_mb=520.5, threads=43),
+    ]
+
+
+def test_parse_cpu_csv_from_path(tmp_path):
+    path = tmp_path / "bench_cpu.csv"
+    path.write_text(
+        "elapsed_s,cpu_pct,mem_mb,threads\n5.0,20.0,512.0,42\n",
+        encoding="utf-8",
+    )
+
+    assert parse_cpu_csv(path) == [
+        CpuRow(elapsed_s=5.0, cpu_pct=20.0, mem_mb=512.0, threads=42)
+    ]
+
+
+def test_parse_cpu_csv_empty_text():
+    assert parse_cpu_csv("") == []
+
+
+def test_parse_cpu_csv_header_only():
+    assert parse_cpu_csv("elapsed_s,cpu_pct,mem_mb,threads\n") == []
+
+
+def test_parse_cpu_csv_ignores_extra_columns():
+    text = "elapsed_s,cpu_pct,mem_mb,threads,extra\n5,20,512,42,ignored\n"
+
+    assert parse_cpu_csv(text) == [
+        CpuRow(elapsed_s=5.0, cpu_pct=20.0, mem_mb=512.0, threads=42)
+    ]
+
+
+def test_parse_cpu_csv_skips_blank_rows():
+    text = "elapsed_s,cpu_pct,mem_mb,threads\n5,20,512,42\n,,,\n10,25,600,44\n"
+
+    assert parse_cpu_csv(text) == [
+        CpuRow(elapsed_s=5.0, cpu_pct=20.0, mem_mb=512.0, threads=42),
+        CpuRow(elapsed_s=10.0, cpu_pct=25.0, mem_mb=600.0, threads=44),
+    ]
+
+
+def test_parse_cpu_csv_missing_required_column():
+    with pytest.raises(ValueError, match="missing required column"):
+        parse_cpu_csv("elapsed_s,cpu_pct,threads\n5,20,42\n")
+
+
+def test_parse_cpu_csv_missing_required_value():
+    with pytest.raises(ValueError, match="Invalid CPU CSV row 2: mem_mb is required"):
+        parse_cpu_csv("elapsed_s,cpu_pct,mem_mb,threads\n5,20,,42\n")
+
+
+def test_parse_cpu_csv_invalid_numeric_value():
+    with pytest.raises(ValueError, match="Invalid CPU CSV row 2"):
+        parse_cpu_csv("elapsed_s,cpu_pct,mem_mb,threads\n5,nope,512,42\n")
+
+
+def test_parse_cpu_csv_threads_accepts_float_string():
+    text = "elapsed_s,cpu_pct,mem_mb,threads\n5,20,512,42.0\n"
+
+    assert parse_cpu_csv(text) == [
+        CpuRow(elapsed_s=5.0, cpu_pct=20.0, mem_mb=512.0, threads=42)
+    ]

--- a/tests/test_bench_db.py
+++ b/tests/test_bench_db.py
@@ -1,0 +1,341 @@
+"""Tests for bench SQLite persistence and the bench record/push CLI commands."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from afterburner.bench.db import (
+    BenchRow,
+    CpuRow,
+    create_run,
+    finish_run,
+    insert_bench_rows,
+    insert_cpu_rows,
+    open_db,
+)
+from afterburner.cli import app
+
+runner = CliRunner()
+
+_MISSION_LUA = """\
+mission =
+{
+["theatre"] =
+"Caucasus",
+["sortie"] =
+"Bench Test",
+["coalition"] =
+{
+["blue"] =
+{
+["country"] =
+{
+[1] =
+{
+["id"] =
+2,
+["name"] =
+"USA",
+["plane"] =
+{
+["group"] =
+{
+},
+},
+},
+},
+},
+},
+["triggers"] =
+{
+},
+["trig"] =
+{
+},
+}
+"""
+
+_BENCH_LOG = """\
+2026-04-25 10:00:00.000 INFO GM_BENCH drift=0.012s groups=20 units=140 elapsed=5.0
+2026-04-25 10:00:05.000 INFO GM_BENCH drift=0.015s groups=21 units=145 elapsed=10.0
+2026-04-25 10:00:10.000 INFO GM_BENCH drift=0.010s groups=22 units=150 elapsed=15.0
+"""
+
+_CPU_CSV = "elapsed_s,cpu_pct,mem_mb,threads\n5.0,35.0,1024.0,20\n10.0,40.0,1050.0,21\n"
+
+
+def _make_miz(path: Path) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mission", _MISSION_LUA)
+        zf.writestr("options", "options =\n{\n}\n")
+        zf.writestr("dictionary", "dictionary =\n{\n}\n")
+        zf.writestr("l10n/DEFAULT/dictionary", "dictionary =\n{\n}\n")
+
+
+# ---------------------------------------------------------------------------
+# db unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_open_db_creates_schema(tmp_path):
+    conn = open_db(tmp_path / "bench.db")
+    tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert {"runs", "bench_timeseries", "cpu_timeseries", "findings"} <= tables
+    conn.close()
+
+
+def test_create_and_finish_run(tmp_path):
+    conn = open_db(tmp_path / "bench.db")
+    run_id = create_run(conn, "TestMission", "2026-04-25T10:00:00+00:00")
+    assert isinstance(run_id, int)
+
+    finish_run(conn, run_id, "2026-04-25T11:00:00+00:00", 3600)
+    row = conn.execute("SELECT mission, duration_s FROM runs WHERE id=?", (run_id,)).fetchone()
+    assert row == ("TestMission", 3600)
+    conn.close()
+
+
+def test_insert_bench_rows(tmp_path):
+    conn = open_db(tmp_path / "bench.db")
+    run_id = create_run(conn, "M", "2026-04-25T10:00:00+00:00")
+    rows = [BenchRow(5.0, 0.01, 20, 140), BenchRow(10.0, 0.02, 21, 145)]
+    insert_bench_rows(conn, run_id, rows)
+
+    stored = conn.execute(
+        "SELECT elapsed_s, groups, units FROM bench_timeseries WHERE run_id=? ORDER BY elapsed_s",
+        (run_id,),
+    ).fetchall()
+    assert stored == [(5.0, 20, 140), (10.0, 21, 145)]
+    conn.close()
+
+
+def test_insert_cpu_rows(tmp_path):
+    conn = open_db(tmp_path / "bench.db")
+    run_id = create_run(conn, "M", "2026-04-25T10:00:00+00:00")
+    rows = [CpuRow(5.0, 35.0, 1024.0, 20)]
+    insert_cpu_rows(conn, run_id, rows)
+
+    stored = conn.execute(
+        "SELECT cpu_pct, mem_mb FROM cpu_timeseries WHERE run_id=?", (run_id,)
+    ).fetchone()
+    assert stored == (35.0, 1024.0)
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# bench record CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_bench_record_basic(tmp_path):
+    miz = tmp_path / "GoonFront.miz"
+    _make_miz(miz)
+    log = tmp_path / "dcs.log"
+    log.write_text(_BENCH_LOG, encoding="utf-8")
+    db = tmp_path / "bench.db"
+
+    result = runner.invoke(
+        app, ["bench", "record", str(miz), "--log", str(log), "--db", str(db)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Recorded run #1" in result.output
+    assert "3 bench samples" in result.output
+
+    conn = open_db(db)
+    count = conn.execute("SELECT COUNT(*) FROM bench_timeseries").fetchone()[0]
+    assert count == 3
+    conn.close()
+
+
+def test_bench_record_with_cpu_csv(tmp_path):
+    miz = tmp_path / "GoonFront.miz"
+    _make_miz(miz)
+    log = tmp_path / "dcs.log"
+    log.write_text(_BENCH_LOG, encoding="utf-8")
+    cpu = tmp_path / "bench_cpu.csv"
+    cpu.write_text(_CPU_CSV, encoding="utf-8")
+    db = tmp_path / "bench.db"
+
+    result = runner.invoke(
+        app,
+        ["bench", "record", str(miz), "--log", str(log), "--cpu", str(cpu), "--db", str(db)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "2 CPU samples" in result.output
+
+    conn = open_db(db)
+    count = conn.execute("SELECT COUNT(*) FROM cpu_timeseries").fetchone()[0]
+    assert count == 2
+    conn.close()
+
+
+def test_bench_record_no_bench_lines_warns(tmp_path):
+    miz = tmp_path / "GoonFront.miz"
+    _make_miz(miz)
+    log = tmp_path / "dcs.log"
+    log.write_text("2026-04-25 10:00:00.000 INFO EDCORE: DCS started\n", encoding="utf-8")
+    db = tmp_path / "bench.db"
+
+    result = runner.invoke(
+        app, ["bench", "record", str(miz), "--log", str(log), "--db", str(db)]
+    )
+    assert result.exit_code == 0
+    assert "Warning" in result.output
+
+    conn = open_db(db)
+    count = conn.execute("SELECT COUNT(*) FROM bench_timeseries").fetchone()[0]
+    assert count == 0
+    conn.close()
+
+
+def test_bench_record_missing_log(tmp_path):
+    miz = tmp_path / "GoonFront.miz"
+    _make_miz(miz)
+    db = tmp_path / "bench.db"
+
+    result = runner.invoke(
+        app,
+        ["bench", "record", str(miz), "--log", str(tmp_path / "missing.log"), "--db", str(db)],
+    )
+    assert result.exit_code == 2
+
+
+def test_bench_record_duration_from_bench_rows(tmp_path):
+    miz = tmp_path / "GoonFront.miz"
+    _make_miz(miz)
+    log = tmp_path / "dcs.log"
+    log.write_text(_BENCH_LOG, encoding="utf-8")
+    db = tmp_path / "bench.db"
+
+    runner.invoke(app, ["bench", "record", str(miz), "--log", str(log), "--db", str(db)])
+
+    conn = open_db(db)
+    duration = conn.execute("SELECT duration_s FROM runs WHERE id=1").fetchone()[0]
+    assert duration == 15  # max elapsed_s from _BENCH_LOG
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# bench push CLI tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_db(db: Path) -> None:
+    """Create a DB with one fully-populated run."""
+    miz = db.parent / "GoonFront.miz"
+    _make_miz(miz)
+    log = db.parent / "dcs.log"
+    log.write_text(_BENCH_LOG, encoding="utf-8")
+    cpu = db.parent / "bench_cpu.csv"
+    cpu.write_text(_CPU_CSV, encoding="utf-8")
+    runner.invoke(
+        app,
+        ["bench", "record", str(miz), "--log", str(log), "--cpu", str(cpu), "--db", str(db)],
+    )
+
+
+def _mock_post(status_code: int = 201, body: dict | None = None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body or {"id": "brun_abc123"}
+    resp.text = json.dumps(body or {"id": "brun_abc123"})
+    if status_code >= 400:
+        import httpx
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_bench_push_latest_run(tmp_path):
+    db = tmp_path / "bench.db"
+    _seed_db(db)
+
+    with patch("httpx.post", return_value=_mock_post()) as mock_post:
+        result = runner.invoke(
+            app,
+            [
+                "bench", "push",
+                "https://example.com",
+                "--host-id", "host_abc",
+                "--key", "secret",
+                "--db", str(db),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "brun_abc123" in result.output
+
+    call_kwargs = mock_post.call_args
+    sent = call_kwargs.kwargs["json"]
+    assert sent["mission"] == "GoonFront"
+    assert len(sent["bench_timeseries"]) == 3
+    assert len(sent["cpu_timeseries"]) == 2
+    assert call_kwargs.kwargs["headers"] == {"X-Host-Id": "host_abc", "X-Agent-Key": "secret"}
+
+
+def test_bench_push_specific_run_id(tmp_path):
+    db = tmp_path / "bench.db"
+    _seed_db(db)
+
+    with patch("httpx.post", return_value=_mock_post()) as mock_post:
+        result = runner.invoke(
+            app,
+            [
+                "bench", "push",
+                "https://example.com",
+                "--host-id", "host_abc",
+                "--key", "secret",
+                "--run-id", "1",
+                "--db", str(db),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_post.called
+
+
+def test_bench_push_missing_db(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "bench", "push",
+            "https://example.com",
+            "--host-id", "host_abc",
+            "--key", "secret",
+            "--db", str(tmp_path / "missing.db"),
+        ],
+    )
+    assert result.exit_code == 2
+
+
+def test_bench_push_http_error(tmp_path):
+    db = tmp_path / "bench.db"
+    _seed_db(db)
+
+    with patch("httpx.post", return_value=_mock_post(status_code=401, body={"detail": "Unauthorized"})):
+        result = runner.invoke(
+            app,
+            [
+                "bench", "push",
+                "https://example.com",
+                "--host-id", "host_abc",
+                "--key", "wrong",
+                "--db", str(db),
+            ],
+        )
+
+    assert result.exit_code == 1

--- a/tests/test_bench_inject.py
+++ b/tests/test_bench_inject.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+from afterburner.bench.inject import _add_trigger, _resource_key_for
+
+
+def test_add_trigger_preserves_sparse_func_table():
+    raw = {
+        "trig": {
+            "conditions": ["return(true)", "return(c_time_after(25))"],
+            "actions": ["action1", "action2"],
+            "flag": [True, True],
+            "func": {
+                2: "if mission.trig.conditions[2]() then mission.trig.actions[2]() end"
+            },
+        },
+        "trigrules": [
+            {
+                "rules": [],
+                "comment": "Mission Start",
+                "eventlist": "",
+                "predicate": "triggerStart",
+                "actions": [],
+            },
+            {
+                "rules": [{"predicate": "c_time_after", "seconds": 25}],
+                "comment": "EWRS",
+                "eventlist": "",
+                "predicate": "triggerOnce",
+                "actions": [
+                    {"predicate": "a_do_script_file", "file": "ResKey_Action_240"}
+                ],
+            },
+        ],
+    }
+
+    _add_trigger(
+        raw,
+        'a_do_script_file(getValueResourceByKey("ResKey_Action_235"))',
+        "ResKey_Action_235",
+    )
+
+    trig = raw["trig"]
+    assert trig["func"][2] == (
+        "if mission.trig.conditions[2]() then mission.trig.actions[2]() end"
+    )
+    assert trig["func"][3] == (
+        "if mission.trig.conditions[3]() then mission.trig.actions[3]() end"
+    )
+    assert trig["conditions"][2] == "return(c_time_after(1))"
+    assert trig["actions"][2] == (
+        'a_do_script_file(getValueResourceByKey("ResKey_Action_235")); '
+        "mission.trig.func[3]=nil;"
+    )
+    assert raw["trigrules"][2] == {
+        "rules": [{"predicate": "c_time_after", "seconds": 1}],
+        "comment": "GM_BENCH",
+        "eventlist": "",
+        "predicate": "triggerOnce",
+        "actions": [{"predicate": "a_do_script_file", "file": "ResKey_Action_235"}],
+        "colorItem": "0x00ff00ff",
+    }
+
+
+def test_add_trigger_rejects_existing_resource_action():
+    raw = {
+        "trig": {
+            "conditions": ["return(c_time_after(1))"],
+            "actions": ['a_do_script_file(getValueResourceByKey("ResKey_Action_235"))'],
+            "flag": [True],
+        }
+    }
+
+    with pytest.raises(RuntimeError, match="GM_BENCH trigger is already present"):
+        _add_trigger(
+            raw,
+            'a_do_script_file(getValueResourceByKey("ResKey_Action_235"))',
+            "ResKey_Action_235",
+        )
+
+
+def test_add_trigger_rejects_existing_trigrule_resource_action():
+    raw = {
+        "trig": {
+            "conditions": [],
+            "actions": [],
+            "flag": [],
+        },
+        "trigrules": [
+            {
+                "comment": "GM_BENCH",
+                "actions": [
+                    {"predicate": "a_do_script_file", "file": "ResKey_Action_235"}
+                ],
+            }
+        ],
+    }
+
+    with pytest.raises(RuntimeError, match="GM_BENCH trigger is already present"):
+        _add_trigger(
+            raw,
+            'a_do_script_file(getValueResourceByKey("ResKey_Action_235"))',
+            "ResKey_Action_235",
+        )
+
+
+def test_resource_key_for_prefers_mission_editor_key_when_free():
+    assert _resource_key_for({"ResKey_Action_234": "x.lua"}) == "ResKey_Action_235"
+
+
+def test_resource_key_for_reuses_existing_gm_bench_resource():
+    assert (
+        _resource_key_for({"ResKey_Action_241": "gm_bench.lua"}) == "ResKey_Action_241"
+    )
+
+
+def test_resource_key_for_appends_when_235_is_taken():
+    assert (
+        _resource_key_for(
+            {"ResKey_Action_235": "other.lua", "ResKey_Action_240": "x.lua"}
+        )
+        == "ResKey_Action_241"
+    )

--- a/tests/test_bench_monitor.py
+++ b/tests/test_bench_monitor.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import argparse
+import csv
+
+import pytest
+
+from tools import bench_monitor
+
+
+class _MemInfo:
+    def __init__(self, rss: int):
+        self.rss = rss
+
+
+class _FakeChild:
+    def __init__(self, pid: int, name: str):
+        self.pid = pid
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
+class _FakeProc:
+    def __init__(
+        self,
+        pid: int,
+        name: str,
+        children: list[_FakeChild] | None = None,
+    ):
+        self.pid = pid
+        self.info = {"pid": pid, "name": name}
+        self._children = children or []
+
+    def children(self) -> list[_FakeChild]:
+        return self._children
+
+
+class _FakePsutilProcess:
+    def __init__(self, cpu_pct: float, rss: int, threads: int):
+        self._cpu_pct = cpu_pct
+        self._rss = rss
+        self._threads = threads
+
+    def cpu_percent(self, interval=None) -> float:
+        return self._cpu_pct
+
+    def memory_info(self) -> _MemInfo:
+        return _MemInfo(self._rss)
+
+    def num_threads(self) -> int:
+        return self._threads
+
+
+def test_is_dcs_process_name_matches_dcs_server_exe():
+    assert bench_monitor._is_dcs_process_name("DCS_server.exe")
+
+
+def test_server_name_from_child_ignores_generic_children():
+    assert bench_monitor._server_name_from_child("conhost.exe") is None
+    assert bench_monitor._server_name_from_child("DCS_server.exe") is None
+
+
+def test_server_name_from_child_strips_exe_suffix():
+    assert bench_monitor._server_name_from_child("MemphisBBQ.exe") == "MemphisBBQ"
+
+
+def test_find_dcs_instances_uses_named_child(monkeypatch):
+    monkeypatch.setattr(
+        bench_monitor.psutil,
+        "process_iter",
+        lambda attrs: [
+            _FakeProc(100, "notepad.exe"),
+            _FakeProc(
+                200,
+                "DCS_server.exe",
+                [_FakeChild(201, "conhost.exe"), _FakeChild(202, "MemphisBBQ.exe")],
+            ),
+        ],
+    )
+
+    assert bench_monitor.find_dcs_instances() == [
+        bench_monitor.DcsInstance("MemphisBBQ", 200, 202)
+    ]
+
+
+def test_find_dcs_instances_falls_back_to_pid_name(monkeypatch):
+    monkeypatch.setattr(
+        bench_monitor.psutil,
+        "process_iter",
+        lambda attrs: [_FakeProc(200, "DCS.exe")],
+    )
+
+    assert bench_monitor.find_dcs_instances() == [
+        bench_monitor.DcsInstance("DCS_200", 200, None)
+    ]
+
+
+def test_cmd_monitor_selects_single_instance_without_server(monkeypatch, tmp_path):
+    selected = {}
+    out_path = tmp_path / "bench_cpu.csv"
+
+    monkeypatch.setattr(
+        bench_monitor,
+        "find_dcs_instances",
+        lambda: [bench_monitor.DcsInstance("MemphisBBQ", 200, None)],
+    )
+    monkeypatch.setattr(
+        bench_monitor,
+        "monitor",
+        lambda instance, interval, out_path, duration: selected.update(
+            {
+                "instance": instance,
+                "interval": interval,
+                "out_path": out_path,
+                "duration": duration,
+            }
+        ),
+    )
+
+    bench_monitor.cmd_monitor(
+        argparse.Namespace(server=None, interval=5.0, out=str(out_path), duration=60.0)
+    )
+
+    assert selected == {
+        "instance": bench_monitor.DcsInstance("MemphisBBQ", 200, None),
+        "interval": 5.0,
+        "out_path": str(out_path),
+        "duration": 60.0,
+    }
+
+
+def test_cmd_monitor_requires_server_when_multiple(monkeypatch):
+    monkeypatch.setattr(
+        bench_monitor,
+        "find_dcs_instances",
+        lambda: [
+            bench_monitor.DcsInstance("MemphisBBQ", 200, None),
+            bench_monitor.DcsInstance("SouthernBBQ", 300, None),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        bench_monitor.cmd_monitor(
+            argparse.Namespace(server=None, interval=5.0, out="x.csv", duration=None)
+        )
+
+    assert "Multiple DCS instances" in str(exc.value)
+
+
+def test_monitor_writes_csv_row(monkeypatch, tmp_path):
+    processes = {
+        200: _FakePsutilProcess(cpu_pct=80.0, rss=512 * 1_048_576, threads=42),
+        201: _FakePsutilProcess(cpu_pct=20.0, rss=128 * 1_048_576, threads=5),
+    }
+    clock = {"now": 0.0}
+
+    monkeypatch.setattr(
+        bench_monitor.psutil,
+        "Process",
+        lambda pid: processes[pid],
+    )
+    monkeypatch.setattr(bench_monitor.psutil, "cpu_count", lambda logical=True: 4)
+    monkeypatch.setattr(bench_monitor.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(
+        bench_monitor.time,
+        "sleep",
+        lambda seconds: clock.update(now=clock["now"] + seconds),
+    )
+
+    out_path = tmp_path / "nested" / "bench_cpu.csv"
+    bench_monitor.monitor(
+        bench_monitor.DcsInstance("MemphisBBQ", 200, 201),
+        interval=5.0,
+        out_path=out_path,
+        duration=5.0,
+    )
+
+    with out_path.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows == [
+        {
+            "timestamp_utc": rows[0]["timestamp_utc"],
+            "elapsed_s": "5.0",
+            "cpu_pct": "20.0",
+            "cpu_pct_raw": "80.0",
+            "mem_mb": "512.0",
+            "threads": "42",
+            "child_cpu_pct": "5.0",
+            "child_mem_mb": "128.0",
+        }
+    ]
+
+
+def test_monitor_rejects_non_positive_interval(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        bench_monitor.monitor(
+            bench_monitor.DcsInstance("MemphisBBQ", 200, None),
+            interval=0,
+            out_path=tmp_path / "bench_cpu.csv",
+        )
+
+    assert "--interval must be greater than 0" in str(exc.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,7 +139,9 @@ def test_analyze_with_log_json(tmp_path):
 def test_analyze_log_missing_file(tmp_path):
     miz = tmp_path / "test.miz"
     _make_miz(miz)
-    result = runner.invoke(app, ["analyze", str(miz), "--log", str(tmp_path / "nope.log")])
+    result = runner.invoke(
+        app, ["analyze", str(miz), "--log", str(tmp_path / "nope.log")]
+    )
     assert result.exit_code == 2
 
 
@@ -327,9 +329,7 @@ def test_report_corrupt_miz(tmp_path):
 
 
 def test_optimize_missing_file(tmp_path):
-    result = runner.invoke(
-        app, ["optimize", str(tmp_path / "nope.miz"), "--safe"]
-    )
+    result = runner.invoke(app, ["optimize", str(tmp_path / "nope.miz"), "--safe"])
     assert result.exit_code == 2
 
 
@@ -352,9 +352,7 @@ def test_optimize_output_already_exists(tmp_path):
 def test_optimize_rejects_same_output_path(tmp_path):
     miz = tmp_path / "mission.miz"
     _make_miz(miz)
-    result = runner.invoke(
-        app, ["optimize", str(miz), "--safe", "--output", str(miz)]
-    )
+    result = runner.invoke(app, ["optimize", str(miz), "--safe", "--output", str(miz)])
     assert result.exit_code == 2
 
 
@@ -424,6 +422,121 @@ def test_logs_fail_on_none_always_zero(tmp_path):
     log.write_text(_FINDING_LOG)
     result = runner.invoke(app, ["logs", str(log), "--fail-on", "none"])
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# bench subcommands
+# ---------------------------------------------------------------------------
+
+
+def test_bench_inject_creates_output(tmp_path):
+    src = tmp_path / "test.miz"
+    out = tmp_path / "test.bench.miz"
+    _make_miz(src)
+
+    result = runner.invoke(app, ["bench", "inject", str(src), "--output", str(out)])
+
+    assert result.exit_code == 0
+    assert out.exists()
+    assert "Injected GM_BENCH" in result.output
+    with zipfile.ZipFile(out) as zf:
+        mission_text = zf.read("mission").decode("utf-8")
+        resource_text = zf.read("l10n/DEFAULT/gm_bench.lua").decode("utf-8")
+        map_resource_text = zf.read("l10n/DEFAULT/mapResource").decode("utf-8")
+    assert "GM_BENCH" in mission_text
+    assert '["conditions"] = {\n      [1] = "return(c_time_after(1))",' in mission_text
+    assert (
+        'a_do_script_file(getValueResourceByKey(\\"ResKey_Action_235\\"))'
+        in mission_text
+    )
+    assert "mission.trig.func[1]=nil" in mission_text
+    assert '["func"] = {\n      [1] = "if mission.trig.conditions[1]()' in mission_text
+    assert '["trigrules"] = {' in mission_text
+    assert '["comment"] = "GM_BENCH"' in mission_text
+    assert '["file"] = "ResKey_Action_235"' in mission_text
+    assert '["predicate"] = "triggerOnce"' in mission_text
+    assert "GM_BENCH started" in resource_text
+    assert "timer.scheduleFunction" in resource_text
+    assert "ResKey_Action_235" in map_resource_text
+    assert "gm_bench.lua" in map_resource_text
+
+
+def test_bench_inject_short_output_option(tmp_path):
+    src = tmp_path / "test.miz"
+    out = tmp_path / "test.bench.miz"
+    _make_miz(src)
+
+    result = runner.invoke(app, ["bench", "inject", str(src), "-o", str(out)])
+
+    assert result.exit_code == 0
+    assert out.exists()
+
+
+def test_bench_inject_missing_file(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "bench",
+            "inject",
+            str(tmp_path / "nope.miz"),
+            "--output",
+            str(tmp_path / "bench.miz"),
+        ],
+    )
+
+    assert result.exit_code == 2
+
+
+def test_bench_inject_wrong_extension(tmp_path):
+    src = tmp_path / "mission.txt"
+    src.write_text("not a miz")
+
+    result = runner.invoke(
+        app,
+        ["bench", "inject", str(src), "--output", str(tmp_path / "bench.miz")],
+    )
+
+    assert result.exit_code == 2
+
+
+def test_bench_inject_rejects_same_output_path(tmp_path):
+    src = tmp_path / "test.miz"
+    _make_miz(src)
+
+    result = runner.invoke(app, ["bench", "inject", str(src), "--output", str(src)])
+
+    assert result.exit_code == 2
+    assert "same as input" in result.output
+
+
+def test_bench_inject_rejects_existing_output(tmp_path):
+    src = tmp_path / "test.miz"
+    out = tmp_path / "test.bench.miz"
+    _make_miz(src)
+    out.write_bytes(b"already here")
+
+    result = runner.invoke(app, ["bench", "inject", str(src), "--output", str(out)])
+
+    assert result.exit_code == 2
+    assert "Output already exists" in result.output
+
+
+def test_bench_inject_rejects_existing_gm_bench_trigger(tmp_path):
+    src = tmp_path / "test.miz"
+    first = tmp_path / "test.bench.miz"
+    second = tmp_path / "test.bench2.miz"
+    _make_miz(src)
+    first_result = runner.invoke(
+        app, ["bench", "inject", str(src), "--output", str(first)]
+    )
+    assert first_result.exit_code == 0
+
+    result = runner.invoke(
+        app, ["bench", "inject", str(first), "--output", str(second)]
+    )
+
+    assert result.exit_code == 2
+    assert "GM_BENCH trigger is already present" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tools/bench_monitor.py
+++ b/tools/bench_monitor.py
@@ -1,13 +1,15 @@
 """
 DCS server CPU/memory benchmark monitor.
 
-Finds DCS.exe instances by their child process names (MemphisBBQ, SouthernBBQ, etc.)
-and samples performance metrics every N seconds into a CSV file.
+Finds DCS.exe / DCS_server.exe instances by their child process names
+(MemphisBBQ, SouthernBBQ, etc.) and samples performance metrics every N
+seconds into a CSV file.
 
 Usage:
     python bench_monitor.py --list
     python bench_monitor.py --server MemphisBBQ --out bench_cpu.csv
     python bench_monitor.py --server MemphisBBQ --interval 2 --out bench_cpu.csv
+    python bench_monitor.py --server MemphisBBQ --duration 3600 --out bench_cpu.csv
 
 Requirements:
     pip install psutil
@@ -20,6 +22,7 @@ import csv
 import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import NamedTuple
 
 try:
@@ -34,41 +37,82 @@ class DcsInstance(NamedTuple):
     child_pid: int | None
 
 
+_CSV_HEADER = [
+    "timestamp_utc",
+    "elapsed_s",
+    "cpu_pct",
+    "cpu_pct_raw",
+    "mem_mb",
+    "threads",
+    "child_cpu_pct",
+    "child_mem_mb",
+]
+
+
 def find_dcs_instances() -> list[DcsInstance]:
     """Return all running DCS.exe instances, identified by their named child process."""
     instances: list[DcsInstance] = []
 
     for proc in psutil.process_iter(["pid", "name"]):
         try:
-            if proc.info["name"] and "DCS" in proc.info["name"] and proc.info["name"].endswith(".exe"):
-                children = proc.children()
-                if children:
-                    for child in children:
-                        try:
-                            child_name = child.name().replace(".exe", "")
-                            # Skip generic Windows sub-processes
-                            if child_name not in ("conhost", "WerFault", "DCS"):
-                                instances.append(DcsInstance(
-                                    server_name=child_name,
-                                    parent_pid=proc.pid,
-                                    child_pid=child.pid,
-                                ))
-                        except (psutil.NoSuchProcess, psutil.AccessDenied):
-                            pass
-                else:
-                    # No named child — list as unnamed
-                    instances.append(DcsInstance(
+            name = proc.info["name"] or ""
+            if not _is_dcs_process_name(name):
+                continue
+
+            children = proc.children()
+            if children:
+                for child in children:
+                    try:
+                        child_name = _server_name_from_child(child.name())
+                        if child_name is None:
+                            continue
+                        instances.append(
+                            DcsInstance(
+                                server_name=child_name,
+                                parent_pid=proc.pid,
+                                child_pid=child.pid,
+                            )
+                        )
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                        pass
+            else:
+                # No named child — list as unnamed
+                instances.append(
+                    DcsInstance(
                         server_name=f"DCS_{proc.pid}",
                         parent_pid=proc.pid,
                         child_pid=None,
-                    ))
+                    )
+                )
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 
     return instances
 
 
-def monitor(instance: DcsInstance, interval: float, out_path: str) -> None:
+def _is_dcs_process_name(name: str) -> bool:
+    normalized = name.lower()
+    return normalized.endswith(".exe") and "dcs" in normalized
+
+
+def _server_name_from_child(name: str) -> str | None:
+    child_name = name.removesuffix(".exe")
+    if child_name.lower() in {"conhost", "werfault", "dcs", "dcs_server"}:
+        return None
+    return child_name
+
+
+def monitor(
+    instance: DcsInstance,
+    interval: float,
+    out_path: str | Path,
+    duration: float | None = None,
+) -> None:
+    if interval <= 0:
+        sys.exit("--interval must be greater than 0")
+    if duration is not None and duration <= 0:
+        sys.exit("--duration must be greater than 0")
+
     try:
         parent = psutil.Process(instance.parent_pid)
     except psutil.NoSuchProcess:
@@ -85,32 +129,36 @@ def monitor(instance: DcsInstance, interval: float, out_path: str) -> None:
             child_proc = None
 
     cpu_count = psutil.cpu_count(logical=True) or 1
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
 
     print(f"Monitoring: {instance.server_name}  (PID {instance.parent_pid})")
     print(f"Output:     {out_path}")
     print(f"Interval:   {interval}s")
+    if duration is not None:
+        print(f"Duration:   {duration}s")
     print(f"CPUs:       {cpu_count} logical")
     print("Press Ctrl+C to stop.\n")
 
     with open(out_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
-        writer.writerow([
-            "timestamp_utc",
-            "elapsed_s",
-            "cpu_pct",           # DCS parent process, normalised to 0-100%
-            "cpu_pct_raw",       # raw psutil value (can exceed 100 on multi-core)
-            "mem_mb",
-            "threads",
-            "child_cpu_pct",     # child process if present, else blank
-            "child_mem_mb",
-        ])
+        writer.writerow(_CSV_HEADER)
         f.flush()
 
         start = time.monotonic()
+        elapsed = 0.0
 
         try:
             while True:
-                time.sleep(interval)
+                if duration is not None and elapsed >= duration:
+                    print(f"\nCompleted {duration:.1f}s — saved to {out_path}")
+                    break
+
+                sleep_for = interval
+                if duration is not None:
+                    sleep_for = min(interval, max(0.0, duration - elapsed))
+                time.sleep(sleep_for)
+
                 now_utc = datetime.now(timezone.utc).isoformat()
                 elapsed = round(time.monotonic() - start, 1)
 
@@ -127,12 +175,25 @@ def monitor(instance: DcsInstance, interval: float, out_path: str) -> None:
                 child_mem = ""
                 if child_proc:
                     try:
-                        child_cpu = round(child_proc.cpu_percent(interval=None) / cpu_count, 2)
+                        child_cpu = round(
+                            child_proc.cpu_percent(interval=None) / cpu_count, 2
+                        )
                         child_mem = round(child_proc.memory_info().rss / 1_048_576, 1)
                     except psutil.NoSuchProcess:
                         child_proc = None
 
-                writer.writerow([now_utc, elapsed, norm_cpu, raw_cpu, mem_mb, threads, child_cpu, child_mem])
+                writer.writerow(
+                    [
+                        now_utc,
+                        elapsed,
+                        norm_cpu,
+                        raw_cpu,
+                        mem_mb,
+                        threads,
+                        child_cpu,
+                        child_mem,
+                    ]
+                )
                 f.flush()
 
                 print(
@@ -153,7 +214,9 @@ def cmd_list() -> None:
     print(f"{'Server':<25} {'Parent PID':>10} {'Child PID':>10}")
     print("-" * 48)
     for inst in instances:
-        print(f"{inst.server_name:<25} {inst.parent_pid:>10} {inst.child_pid or '—':>10}")
+        print(
+            f"{inst.server_name:<25} {inst.parent_pid:>10} {inst.child_pid or '—':>10}"
+        )
 
 
 def cmd_monitor(args: argparse.Namespace) -> None:
@@ -171,9 +234,11 @@ def cmd_monitor(args: argparse.Namespace) -> None:
         instance = matches[0]
     else:
         names = ", ".join(i.server_name for i in instances)
-        sys.exit(f"Multiple DCS instances found — specify one with --server. Running: {names}")
+        sys.exit(
+            f"Multiple DCS instances found — specify one with --server. Running: {names}"
+        )
 
-    monitor(instance, interval=args.interval, out_path=args.out)
+    monitor(instance, interval=args.interval, out_path=args.out, duration=args.duration)
 
 
 def main() -> None:
@@ -181,10 +246,29 @@ def main() -> None:
         prog="bench_monitor",
         description="Monitor DCS server CPU/memory during a benchmark soak run.",
     )
-    parser.add_argument("--list", action="store_true", help="List running DCS instances and exit")
-    parser.add_argument("--server", default=None, help="Server name to monitor (e.g. MemphisBBQ)")
-    parser.add_argument("--interval", type=float, default=1.0, help="Sample interval in seconds (default: 1)")
-    parser.add_argument("--out", default="bench_cpu.csv", help="Output CSV path (default: bench_cpu.csv)")
+    parser.add_argument(
+        "--list", action="store_true", help="List running DCS instances and exit"
+    )
+    parser.add_argument(
+        "--server", default=None, help="Server name to monitor (e.g. MemphisBBQ)"
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Sample interval in seconds (default: 5)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Stop automatically after this many seconds",
+    )
+    parser.add_argument(
+        "--out",
+        default="bench_cpu.csv",
+        help="Output CSV path (default: bench_cpu.csv)",
+    )
     args = parser.parse_args()
 
     if args.list:


### PR DESCRIPTION
Closes #19, Closes #20

## Summary

- **`afterburner/bench/`** — full bench module: SQLite schema (`db.py`), GM_BENCH log parser, CPU CSV parser, `.miz` injector (`inject.py`), and `gm_bench.lua` Lua timer script
- **`bench record`** — parses GM_BENCH lines + bench_monitor CSV into a local SQLite DB; defaults to `~/.afterburner/bench.db`
- **`bench push`** — POSTs a recorded run to the dcs-bullseye orchestrator via agent-key auth (`X-Host-Id` / `X-Agent-Key`); defaults to latest run
- **`bench_monitor.py`** — added `--duration` flag, extracted CSV header constant, improved `DCS_server.exe` detection
- **`httpx`** added as a dependency for `bench push`
- Full test coverage for all new code

## Workflow (post-session)

```
afterburner bench record Vietguam.miz --log dcs.log --cpu bench_cpu.csv --db bench.db
afterburner bench push https://<vps> --host-id <id> --key <key> --db bench.db
```

## Test plan

- [x] `pytest` — 274 passed, 0 failed
- [x] `bench record` against a real DCS log on the Windows node
- [x] `bench push` to the orchestrator with real agent credentials