### PR TITLE
feat: add reusable workflow for external mission linting

### DIFF
--- a/.github/workflows/mission-lint-reusable.yml
+++ b/.github/workflows/mission-lint-reusable.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_call:
+    inputs:
+      miz-glob:
+        type: string
+        default: "**/*.miz"
+        required: false
+      fail-on:
+        type: string
+        default: critical
+        required: false
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - run: pip install dcs-afterburner
+
+      - run: afterburner analyze ${{ inputs.miz-glob }} --fail-on ${{ inputs.fail-on }}


### PR DESCRIPTION
## Overview
This PR adds a reusable GitHub Actions workflow (`.github/workflows/mission-lint-reusable.yml`), satisfying the requirements to allow external repositories to invoke Afterburner's mission linting.

## Key Features
* Uses `on: workflow_call` to make the action importable.
* Exposes `miz-glob` (default: `**/*.miz`) and `fail-on` (default: `critical`) as configurable inputs.
* Automatically checks out the calling repository's code, sets up Python, installs `dcs-afterburner`, and runs the CLI analysis.

## Usage for External Repos
Other repositories can now trigger this check by adding the following to their workflows:

```yaml
jobs:
  lint-missions:
    uses: IT-Dev-Group-6/dcs-afterburner/.github/workflows/mission-lint-reusable.yml@master
    with:
      fail-on: warning