### PR TITLE
Bench/sqlite persistence

### DIFF
--- a/afterburner/bench/db.py
+++ b/afterburner/bench/db.py
@@ -18,6 +18,11 @@ CREATE TABLE IF NOT EXISTS runs (
     started_at  TEXT    NOT NULL,
     ended_at    TEXT,
     duration_s  INTEGER,
+    intended_duration_s INTEGER,
+    bench_elapsed_s INTEGER,
+    run_quality TEXT NOT NULL DEFAULT 'unknown',
+    injection_status TEXT,
+    hard_stop_error TEXT,
     notes       TEXT
 );
 
@@ -44,9 +49,20 @@ CREATE TABLE IF NOT EXISTS findings (
     detail   TEXT
 );
 
+CREATE TABLE IF NOT EXISTS log_issues (
+    run_id     INTEGER NOT NULL REFERENCES runs(id),
+    issue_type TEXT    NOT NULL,
+    signature  TEXT    NOT NULL,
+    count      INTEGER NOT NULL,
+    first_line TEXT,
+    last_line  TEXT,
+    detail     TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_bench_run    ON bench_timeseries(run_id);
 CREATE INDEX IF NOT EXISTS idx_cpu_run      ON cpu_timeseries(run_id);
 CREATE INDEX IF NOT EXISTS idx_findings_run ON findings(run_id);
+CREATE INDEX IF NOT EXISTS idx_log_issues_run ON log_issues(run_id);
 """
 
 
@@ -66,10 +82,36 @@ class CpuRow:
     threads: int
 
 
+@dataclass
+class StoredLogIssue:
+    issue_type: str
+    signature: str
+    count: int
+    first_line: str | None = None
+    last_line: str | None = None
+    detail: str | None = None
+
+
 def open_db(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(path)
     conn.executescript(_SCHEMA)
+    _migrate_runs(conn)
     return conn
+
+
+def _migrate_runs(conn: sqlite3.Connection) -> None:
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
+    migrations = {
+        "intended_duration_s": "ALTER TABLE runs ADD COLUMN intended_duration_s INTEGER",
+        "bench_elapsed_s": "ALTER TABLE runs ADD COLUMN bench_elapsed_s INTEGER",
+        "run_quality": "ALTER TABLE runs ADD COLUMN run_quality TEXT NOT NULL DEFAULT 'unknown'",
+        "injection_status": "ALTER TABLE runs ADD COLUMN injection_status TEXT",
+        "hard_stop_error": "ALTER TABLE runs ADD COLUMN hard_stop_error TEXT",
+    }
+    for column, sql in migrations.items():
+        if column not in existing:
+            conn.execute(sql)
+    conn.commit()
 
 
 def create_run(
@@ -91,10 +133,35 @@ def finish_run(
     run_id: int,
     ended_at: str,
     duration_s: int,
+    *,
+    intended_duration_s: int | None = None,
+    bench_elapsed_s: int | None = None,
+    run_quality: str = "unknown",
+    injection_status: str | None = None,
+    hard_stop_error: str | None = None,
 ) -> None:
     conn.execute(
-        "UPDATE runs SET ended_at=?, duration_s=? WHERE id=?",
-        (ended_at, duration_s, run_id),
+        """
+        UPDATE runs
+        SET ended_at=?,
+            duration_s=?,
+            intended_duration_s=?,
+            bench_elapsed_s=?,
+            run_quality=?,
+            injection_status=?,
+            hard_stop_error=?
+        WHERE id=?
+        """,
+        (
+            ended_at,
+            duration_s,
+            intended_duration_s,
+            bench_elapsed_s,
+            run_quality,
+            injection_status,
+            hard_stop_error,
+            run_id,
+        ),
     )
     conn.commit()
 
@@ -135,6 +202,29 @@ def insert_findings(
     conn.commit()
 
 
+def insert_log_issues(
+    conn: sqlite3.Connection,
+    run_id: int,
+    issues: list[StoredLogIssue],
+) -> None:
+    conn.executemany(
+        "INSERT INTO log_issues VALUES (?,?,?,?,?,?,?)",
+        [
+            (
+                run_id,
+                i.issue_type,
+                i.signature,
+                i.count,
+                i.first_line,
+                i.last_line,
+                i.detail,
+            )
+            for i in issues
+        ],
+    )
+    conn.commit()
+
+
 def get_run(conn: sqlite3.Connection, run_id: int) -> dict | None:
     conn.row_factory = sqlite3.Row
     row = conn.execute("SELECT * FROM runs WHERE id=?", (run_id,)).fetchone()
@@ -170,6 +260,20 @@ def get_finding_rows(conn: sqlite3.Connection, run_id: int) -> list[dict]:
     conn.row_factory = sqlite3.Row
     rows = conn.execute(
         "SELECT rule_id, severity, detail FROM findings WHERE run_id=?",
+        (run_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_log_issue_rows(conn: sqlite3.Connection, run_id: int) -> list[dict]:
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT issue_type, signature, count, first_line, last_line, detail
+        FROM log_issues
+        WHERE run_id=?
+        ORDER BY issue_type, count DESC
+        """,
         (run_id,),
     ).fetchall()
     return [dict(r) for r in rows]

--- a/afterburner/bench/log_issues.py
+++ b/afterburner/bench/log_issues.py
@@ -1,0 +1,121 @@
+"""Extract benchmark-relevant scripting issues from DCS logs."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class LogIssue:
+    issue_type: str
+    signature: str
+    count: int
+    first_line: str | None = None
+    last_line: str | None = None
+    detail: str | None = None
+
+
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\s+")
+_MISSION_SCRIPT_ERROR_RE = re.compile(r"Mission script error:\s*(.*)")
+_SCRIPTING_ERROR_RE = re.compile(r"\b(?:SCRIPTING|Scripting) \([^)]*\):\s*(.*)")
+
+
+def parse_log_issues(
+    source: str | Path,
+    *,
+    repeated_threshold: int = 10,
+    ignored_signatures: set[str] | None = None,
+) -> list[LogIssue]:
+    """Return hard-stop and repeated scripting issues from a DCS log.
+
+    Hard-stop mission script errors are always returned, even when seen once.
+    Other scripting errors are returned only when the normalized signature count
+    reaches repeated_threshold.
+    """
+    if isinstance(source, Path):
+        text = source.read_text(encoding="utf-8", errors="replace")
+    else:
+        text = source
+
+    ignored = ignored_signatures or set()
+    lines = text.splitlines()
+    issues: list[LogIssue] = []
+    counter: Counter[str] = Counter()
+    first_line: dict[str, str] = {}
+    last_line: dict[str, str] = {}
+
+    for i, line in enumerate(lines):
+        if "Mission script error:" in line:
+            signature = _normalize_mission_script_error(line)
+            if signature not in ignored:
+                issues.append(
+                    LogIssue(
+                        issue_type="hard_stop",
+                        signature=signature,
+                        count=1,
+                        first_line=line,
+                        last_line=line,
+                        detail=_stack_block(lines, i),
+                    )
+                )
+
+        if "ERROR" not in line or not _is_scripting_line(line):
+            continue
+
+        signature = _normalize_scripting_error(line)
+        if not signature or signature in ignored:
+            continue
+        counter[signature] += 1
+        first_line.setdefault(signature, line)
+        last_line[signature] = line
+
+    for signature, count in counter.most_common():
+        if count < repeated_threshold:
+            continue
+        issues.append(
+            LogIssue(
+                issue_type="repeated_scripting",
+                signature=signature,
+                count=count,
+                first_line=first_line.get(signature),
+                last_line=last_line.get(signature),
+            )
+        )
+
+    return issues
+
+
+def _is_scripting_line(line: str) -> bool:
+    return " SCRIPTING " in line or " Scripting " in line
+
+
+def _normalize_mission_script_error(line: str) -> str:
+    match = _MISSION_SCRIPT_ERROR_RE.search(line)
+    if match:
+        return "Mission script error: " + match.group(1).strip()
+    return _strip_timestamp(line).strip()
+
+
+def _normalize_scripting_error(line: str) -> str:
+    stripped = _strip_timestamp(line).strip()
+    match = _SCRIPTING_ERROR_RE.search(stripped)
+    if match:
+        return match.group(1).strip()
+    return stripped
+
+
+def _strip_timestamp(line: str) -> str:
+    return _TS_RE.sub("", line)
+
+
+def _stack_block(lines: list[str], start: int) -> str:
+    block = [lines[start]]
+    for line in lines[start + 1 :]:
+        if line.startswith("\t") or line.startswith("stack traceback:"):
+            block.append(line)
+            continue
+        break
+    return "\n".join(block)

--- a/afterburner/bench/native_events.py
+++ b/afterburner/bench/native_events.py
@@ -29,7 +29,7 @@ class NativeEvent:
     @property
     def elapsed_s(self) -> float | None:
         value = self.fields.get("t")
-        if value in (None, ""):
+        if value is None or value == "":
             return None
         try:
             return float(value)

--- a/afterburner/bench/native_events.py
+++ b/afterburner/bench/native_events.py
@@ -1,0 +1,80 @@
+"""Parse native DCS ``Scripting event:`` log lines."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+_EVENT_RE = re.compile(
+    r"^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) "
+    r".*?\bScripting \(Main\): event:(?P<payload>.*)$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class NativeEvent:
+    timestamp: datetime
+    type: str
+    fields: dict[str, str]
+
+    @property
+    def player(self) -> str | None:
+        return self.fields.get("initiatorPilotName") or self.fields.get(
+            "targetPilotName"
+        )
+
+    @property
+    def elapsed_s(self) -> float | None:
+        value = self.fields.get("t")
+        if value in (None, ""):
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            return None
+
+
+def parse_native_events(source: str | Path) -> list[NativeEvent]:
+    """Parse DCS native scripting event lines from text or a log path."""
+    text = (
+        source.read_text(encoding="utf-8", errors="replace")
+        if isinstance(source, Path)
+        else source
+    )
+
+    events: list[NativeEvent] = []
+    for line in text.splitlines():
+        match = _EVENT_RE.search(line)
+        if not match:
+            continue
+
+        fields = _parse_fields(match.group("payload"))
+        event_type = fields.get("type", "")
+        if not event_type:
+            continue
+
+        events.append(
+            NativeEvent(
+                timestamp=datetime.strptime(
+                    match.group("timestamp"), "%Y-%m-%d %H:%M:%S.%f"
+                ),
+                type=event_type,
+                fields=fields,
+            )
+        )
+    return events
+
+
+def _parse_fields(payload: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for part in payload.split(","):
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        key = key.strip()
+        if key:
+            fields[key] = value.strip()
+    return fields

--- a/afterburner/cli.py
+++ b/afterburner/cli.py
@@ -423,19 +423,32 @@ def bench_record(
         help="SQLite DB path (created if absent)",
     ),
     notes: str = typer.Option(None, "--notes", help="Free-text notes for this run"),
+    intended_duration_s: int | None = typer.Option(
+        None,
+        "--intended-duration",
+        help="Expected benchmark duration in seconds from the queue/orchestrator",
+    ),
+    injection_status: str | None = typer.Option(
+        None,
+        "--injection-status",
+        help="Result of scheduler/agent injection step, e.g. injected/already_injected/failed",
+    ),
 ) -> None:
     """Import a GM_BENCH run into the SQLite database."""
     from datetime import datetime, timezone
 
     from afterburner.bench.cpu_parser import parse_cpu_csv
     from afterburner.bench.db import (
+        StoredLogIssue,
         create_run,
         finish_run,
         insert_bench_rows,
         insert_cpu_rows,
         insert_findings,
+        insert_log_issues,
         open_db,
     )
+    from afterburner.bench.log_issues import parse_log_issues
     from afterburner.bench.log_parser import parse_bench_log
 
     for label, path in [("Mission", mission), ("Log", log_file)]:
@@ -454,6 +467,7 @@ def bench_record(
         _err.print(
             "[yellow]Warning:[/yellow] No GM_BENCH lines found in log — is gm_bench.lua injected?"
         )
+    log_issues = parse_log_issues(log_file)
 
     cpu_rows = []
     if cpu_csv is not None:
@@ -483,16 +497,51 @@ def bench_record(
         insert_cpu_rows(conn, run_id, cpu_rows)
     if findings:
         insert_findings(conn, run_id, findings)
+    if log_issues:
+        insert_log_issues(
+            conn,
+            run_id,
+            [
+                StoredLogIssue(
+                    issue_type=i.issue_type,
+                    signature=i.signature,
+                    count=i.count,
+                    first_line=i.first_line,
+                    last_line=i.last_line,
+                    detail=i.detail,
+                )
+                for i in log_issues
+            ],
+        )
 
-    duration_s = int(max((r.elapsed_s for r in bench_rows), default=0))
-    finish_run(conn, run_id, now, duration_s)
+    bench_elapsed_s = int(max((r.elapsed_s for r in bench_rows), default=0))
+    duration_s = intended_duration_s or bench_elapsed_s
+    hard_stop = next((i for i in log_issues if i.issue_type == "hard_stop"), None)
+    run_quality = _bench_run_quality(
+        bench_rows=len(bench_rows),
+        bench_elapsed_s=bench_elapsed_s,
+        intended_duration_s=intended_duration_s,
+        hard_stop=hard_stop is not None,
+    )
+    finish_run(
+        conn,
+        run_id,
+        now,
+        duration_s,
+        intended_duration_s=intended_duration_s,
+        bench_elapsed_s=bench_elapsed_s,
+        run_quality=run_quality,
+        injection_status=injection_status,
+        hard_stop_error=hard_stop.signature if hard_stop else None,
+    )
     conn.close()
 
     con = Console()
     con.print(
         f"[green]Recorded run #{run_id}:[/green] {mission.stem}  "
         f"[dim]{len(bench_rows)} bench samples, {len(cpu_rows)} CPU samples, "
-        f"{len(findings)} findings, {duration_s}s[/dim]"
+        f"{len(findings)} findings, {len(log_issues)} log issues, "
+        f"{duration_s}s, quality={run_quality}[/dim]"
     )
     con.print(f"[dim]DB: {db_path}[/dim]")
 
@@ -522,6 +571,7 @@ def bench_push(
         get_bench_rows,
         get_cpu_rows,
         get_finding_rows,
+        get_log_issue_rows,
         get_run,
         latest_run_id,
         open_db,
@@ -546,6 +596,7 @@ def bench_push(
     bench_rows = get_bench_rows(conn, resolved_id)
     cpu_rows = get_cpu_rows(conn, resolved_id)
     finding_rows = get_finding_rows(conn, resolved_id)
+    log_issue_rows = get_log_issue_rows(conn, resolved_id)
     conn.close()
 
     payload = {
@@ -553,6 +604,11 @@ def bench_push(
         "started_at": run["started_at"],
         "ended_at": run.get("ended_at"),
         "duration_s": run.get("duration_s"),
+        "intended_duration_s": run.get("intended_duration_s"),
+        "bench_elapsed_s": run.get("bench_elapsed_s"),
+        "run_quality": run.get("run_quality"),
+        "injection_status": run.get("injection_status"),
+        "hard_stop_error": run.get("hard_stop_error"),
         "notes": run.get("notes"),
         "bench_timeseries": [
             {
@@ -573,6 +629,7 @@ def bench_push(
             for r in cpu_rows
         ],
         "findings": finding_rows,
+        "log_issues": log_issue_rows,
     }
 
     endpoint = url.rstrip("/") + "/api/v1/bench/runs"
@@ -597,8 +654,29 @@ def bench_push(
     con = Console()
     con.print(
         f"[green]Pushed run #{resolved_id}[/green] → orchestrator run [bold]{remote_id}[/bold]  "
-        f"[dim]{len(bench_rows)} bench, {len(cpu_rows)} CPU, {len(finding_rows)} findings[/dim]"
+        f"[dim]{len(bench_rows)} bench, {len(cpu_rows)} CPU, {len(finding_rows)} findings, "
+        f"{len(log_issue_rows)} log issues[/dim]"
     )
+
+
+def _bench_run_quality(
+    *,
+    bench_rows: int,
+    bench_elapsed_s: int,
+    intended_duration_s: int | None,
+    hard_stop: bool,
+) -> str:
+    if hard_stop and bench_rows == 0:
+        return "mission_script_hard_stop"
+    if bench_rows == 0:
+        return "no_bench_rows"
+    if hard_stop:
+        return "partial_bench_rows"
+    if intended_duration_s and bench_elapsed_s < max(
+        30, int(intended_duration_s * 0.8)
+    ):
+        return "partial_bench_rows"
+    return "ok"
 
 
 def _check_fail_on(report: Report, fail_on: str) -> None:

--- a/docs/bench.html
+++ b/docs/bench.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DCS Afterburner — Bench</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --base:     #1e1e2e;
+      --mantle:   #181825;
+      --crust:    #11111b;
+      --surface0: #313244;
+      --surface1: #45475a;
+      --surface2: #585b70;
+      --overlay0: #6c7086;
+      --overlay1: #7f849c;
+      --text:     #cdd6f4;
+      --subtext0: #a6adc8;
+      --subtext1: #bac2de;
+      --blue:     #89b4fa;
+      --green:    #a6e3a1;
+      --red:      #f38ba8;
+      --yellow:   #f9e2af;
+      --peach:    #fab387;
+      --mauve:    #cba6f7;
+      --teal:     #94e2d5;
+      --sky:      #89dceb;
+    }
+
+    html { min-height: 100%; background: var(--crust); }
+
+    body {
+      font-family: 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
+      font-size: 13.5px;
+      line-height: 1.5;
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 24px 16px 48px;
+      min-height: 100vh;
+      background: var(--crust);
+      gap: 20px;
+    }
+
+    .window {
+      width: 100%;
+      max-width: 960px;
+      border-radius: 10px;
+      overflow: hidden;
+      box-shadow: 0 24px 80px rgba(0,0,0,.7);
+    }
+
+    .titlebar {
+      background: var(--mantle);
+      padding: 11px 16px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      border-bottom: 1px solid var(--surface0);
+      user-select: none;
+    }
+    .win-controls { display: flex; gap: 7px; }
+    .wc { width: 12px; height: 12px; border-radius: 50%; }
+    .wc-close  { background: #f38ba8; }
+    .wc-min    { background: #f9e2af; }
+    .wc-max    { background: #a6e3a1; }
+    .win-title { flex: 1; text-align: center; font-size: 12px; color: var(--overlay0); }
+
+    .panel {
+      background: var(--base);
+      padding: 20px 24px;
+    }
+
+    h1 {
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--blue);
+      margin-bottom: 4px;
+    }
+    .subtitle { color: var(--overlay1); font-size: 12px; margin-bottom: 20px; }
+
+    /* Run list */
+    .run-list { display: flex; flex-direction: column; gap: 8px; }
+
+    .run-card {
+      background: var(--mantle);
+      border: 1px solid var(--surface0);
+      border-radius: 6px;
+      padding: 12px 16px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      transition: border-color 0.15s;
+    }
+    .run-card:hover { border-color: var(--blue); }
+    .run-card.active { border-color: var(--blue); background: var(--surface0); }
+
+    .run-mission { font-weight: 700; color: var(--text); flex: 1; }
+    .run-meta { color: var(--subtext0); font-size: 12px; text-align: right; }
+    .run-duration { color: var(--teal); font-size: 12px; }
+
+    /* Detail panel */
+    .detail { display: none; flex-direction: column; gap: 20px; }
+    .detail.visible { display: flex; }
+
+    .detail-header {
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+      border-bottom: 1px solid var(--surface0);
+      padding-bottom: 12px;
+    }
+    .detail-mission { font-size: 15px; font-weight: 700; color: var(--blue); }
+    .detail-meta { color: var(--subtext0); font-size: 12px; }
+
+    .charts-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+    @media (max-width: 640px) { .charts-grid { grid-template-columns: 1fr; } }
+
+    .chart-box {
+      background: var(--mantle);
+      border: 1px solid var(--surface0);
+      border-radius: 6px;
+      padding: 14px;
+    }
+    .chart-label {
+      font-size: 11px;
+      color: var(--overlay1);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 10px;
+    }
+    canvas { max-height: 180px; }
+
+    /* Findings */
+    .findings-list { display: flex; flex-direction: column; gap: 6px; }
+    .finding {
+      display: flex;
+      gap: 10px;
+      background: var(--mantle);
+      border: 1px solid var(--surface0);
+      border-radius: 6px;
+      padding: 10px 14px;
+      align-items: baseline;
+    }
+    .sev { font-size: 11px; font-weight: 700; min-width: 64px; text-transform: uppercase; }
+    .sev-critical { color: var(--red); }
+    .sev-warning  { color: var(--yellow); }
+    .sev-info     { color: var(--sky); }
+    .finding-rule { color: var(--mauve); min-width: 80px; }
+    .finding-detail { color: var(--subtext1); font-size: 12px; }
+
+    .empty { color: var(--overlay0); font-size: 12px; padding: 12px 0; }
+    .back-btn {
+      background: none;
+      border: 1px solid var(--surface1);
+      border-radius: 4px;
+      color: var(--subtext0);
+      padding: 4px 10px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 12px;
+    }
+    .back-btn:hover { border-color: var(--blue); color: var(--blue); }
+
+    .loading { color: var(--overlay0); font-size: 12px; }
+    .error-msg { color: var(--red); font-size: 12px; }
+
+    .section-title {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--overlay1);
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+
+<div class="window">
+  <div class="titlebar">
+    <div class="win-controls">
+      <div class="wc wc-close"></div>
+      <div class="wc wc-min"></div>
+      <div class="wc wc-max"></div>
+    </div>
+    <div class="win-title">afterburner — bench dashboard</div>
+  </div>
+  <div class="panel">
+
+    <!-- Run list view -->
+    <div id="view-list">
+      <h1>Bench Runs</h1>
+      <div class="subtitle">DCS server performance captured via GM_BENCH</div>
+      <div id="run-list-container" class="run-list">
+        <div class="loading">Loading runs…</div>
+      </div>
+    </div>
+
+    <!-- Run detail view -->
+    <div id="view-detail" class="detail">
+      <div class="detail-header">
+        <button class="back-btn" onclick="showList()">← back</button>
+        <span class="detail-mission" id="detail-mission"></span>
+        <span class="detail-meta" id="detail-meta"></span>
+      </div>
+
+      <div>
+        <div class="section-title">Scheduler &amp; AI Load</div>
+        <div class="charts-grid">
+          <div class="chart-box">
+            <div class="chart-label">Scheduler Drift (s)</div>
+            <canvas id="chart-drift"></canvas>
+          </div>
+          <div class="chart-box">
+            <div class="chart-label">Active Groups / Units</div>
+            <canvas id="chart-groups"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <div id="cpu-section" style="display:none">
+        <div class="section-title">Server CPU &amp; Memory</div>
+        <div class="charts-grid">
+          <div class="chart-box">
+            <div class="chart-label">CPU %</div>
+            <canvas id="chart-cpu"></canvas>
+          </div>
+          <div class="chart-box">
+            <div class="chart-label">Memory (MB)</div>
+            <canvas id="chart-mem"></canvas>
+          </div>
+        </div>
+      </div>
+
+      <div id="findings-section">
+        <div class="section-title">Mission Findings</div>
+        <div id="findings-list" class="findings-list"></div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+const API = 'https://goon.gsquad.cc/api/v1';
+const charts = {};
+
+function fmtDuration(s) {
+  if (!s) return '—';
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  });
+}
+
+function chartDefaults(label, color) {
+  return {
+    type: 'line',
+    options: {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: true,
+      plugins: { legend: { display: label !== null } },
+      scales: {
+        x: { ticks: { color: '#6c7086', font: { family: 'Fira Code', size: 10 } }, grid: { color: '#313244' } },
+        y: { ticks: { color: '#6c7086', font: { family: 'Fira Code', size: 10 } }, grid: { color: '#313244' } },
+      },
+    },
+  };
+}
+
+function makeChart(id, datasets, xLabels, showLegend) {
+  if (charts[id]) charts[id].destroy();
+  const cfg = chartDefaults(showLegend ? true : null);
+  cfg.data = { labels: xLabels, datasets };
+  if (!showLegend) cfg.options.plugins.legend.display = false;
+  charts[id] = new Chart(document.getElementById(id), cfg);
+}
+
+function line(label, data, color) {
+  return {
+    label,
+    data,
+    borderColor: color,
+    backgroundColor: color + '22',
+    borderWidth: 1.5,
+    pointRadius: 0,
+    tension: 0.3,
+    fill: true,
+  };
+}
+
+async function loadRuns() {
+  const container = document.getElementById('run-list-container');
+  try {
+    const resp = await fetch(`${API}/bench/runs?limit=50`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const runs = await resp.json();
+    if (!runs.length) {
+      container.innerHTML = '<div class="empty">No runs recorded yet.</div>';
+      return;
+    }
+    container.innerHTML = '';
+    for (const run of runs) {
+      const card = document.createElement('div');
+      card.className = 'run-card';
+      card.innerHTML = `
+        <div class="run-mission">${run.mission}</div>
+        <div class="run-duration">${fmtDuration(run.duration_s)}</div>
+        <div class="run-meta">${fmtDate(run.started_at)}</div>
+      `;
+      card.addEventListener('click', () => loadRun(run.id, card));
+      container.appendChild(card);
+    }
+  } catch (e) {
+    container.innerHTML = `<div class="error-msg">Failed to load runs: ${e.message}</div>`;
+  }
+}
+
+async function loadRun(runId, card) {
+  document.querySelectorAll('.run-card').forEach(c => c.classList.remove('active'));
+  if (card) card.classList.add('active');
+
+  document.getElementById('view-list').style.display = 'none';
+  const detail = document.getElementById('view-detail');
+  detail.classList.add('visible');
+  document.getElementById('detail-mission').textContent = '…';
+
+  try {
+    const resp = await fetch(`${API}/bench/runs/${runId}`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const run = await resp.json();
+
+    document.getElementById('detail-mission').textContent = run.mission;
+    document.getElementById('detail-meta').textContent =
+      `${fmtDate(run.started_at)}  ·  ${fmtDuration(run.duration_s)}`;
+
+    const ts = run.bench_timeseries || [];
+    const labels = ts.map(r => `${Math.round(r.elapsed_s / 60)}m`);
+
+    makeChart('chart-drift', [line('drift', ts.map(r => r.drift_s.toFixed(3)), '#f38ba8')], labels, false);
+    makeChart('chart-groups', [
+      line('groups', ts.map(r => r.groups), '#89b4fa'),
+      line('units',  ts.map(r => r.units),  '#a6e3a1'),
+    ], labels, true);
+
+    const cpu = run.cpu_timeseries || [];
+    const cpuSection = document.getElementById('cpu-section');
+    if (cpu.length) {
+      cpuSection.style.display = '';
+      const cpuLabels = cpu.map(r => `${Math.round(r.elapsed_s / 60)}m`);
+      makeChart('chart-cpu', [line('cpu %', cpu.map(r => r.cpu_pct.toFixed(1)), '#fab387')], cpuLabels, false);
+      makeChart('chart-mem', [line('mem MB', cpu.map(r => r.mem_mb.toFixed(0)), '#cba6f7')], cpuLabels, false);
+    } else {
+      cpuSection.style.display = 'none';
+    }
+
+    const findings = run.findings || [];
+    const fl = document.getElementById('findings-list');
+    if (!findings.length) {
+      fl.innerHTML = '<div class="empty">No findings.</div>';
+    } else {
+      fl.innerHTML = findings.map(f => `
+        <div class="finding">
+          <span class="sev sev-${f.severity}">${f.severity}</span>
+          <span class="finding-rule">${f.rule_id}</span>
+          <span class="finding-detail">${f.detail || ''}</span>
+        </div>
+      `).join('');
+    }
+
+  } catch (e) {
+    document.getElementById('detail-mission').textContent = `Error: ${e.message}`;
+  }
+}
+
+function showList() {
+  document.getElementById('view-list').style.display = '';
+  document.getElementById('view-detail').classList.remove('visible');
+  document.querySelectorAll('.run-card').forEach(c => c.classList.remove('active'));
+}
+
+loadRuns();
+</script>
+</body>
+</html>

--- a/tests/test_bench_db.py
+++ b/tests/test_bench_db.py
@@ -7,7 +7,6 @@ import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from typer.testing import CliRunner
 
 from afterburner.bench.db import (
@@ -15,6 +14,7 @@ from afterburner.bench.db import (
     CpuRow,
     create_run,
     finish_run,
+    get_log_issue_rows,
     insert_bench_rows,
     insert_cpu_rows,
     open_db,
@@ -91,7 +91,13 @@ def test_open_db_creates_schema(tmp_path):
             "SELECT name FROM sqlite_master WHERE type='table'"
         ).fetchall()
     }
-    assert {"runs", "bench_timeseries", "cpu_timeseries", "findings"} <= tables
+    assert {
+        "runs",
+        "bench_timeseries",
+        "cpu_timeseries",
+        "findings",
+        "log_issues",
+    } <= tables
     conn.close()
 
 
@@ -100,9 +106,21 @@ def test_create_and_finish_run(tmp_path):
     run_id = create_run(conn, "TestMission", "2026-04-25T10:00:00+00:00")
     assert isinstance(run_id, int)
 
-    finish_run(conn, run_id, "2026-04-25T11:00:00+00:00", 3600)
-    row = conn.execute("SELECT mission, duration_s FROM runs WHERE id=?", (run_id,)).fetchone()
-    assert row == ("TestMission", 3600)
+    finish_run(
+        conn,
+        run_id,
+        "2026-04-25T11:00:00+00:00",
+        3600,
+        intended_duration_s=1800,
+        bench_elapsed_s=15,
+        run_quality="ok",
+        injection_status="injected",
+    )
+    row = conn.execute(
+        "SELECT mission, duration_s, intended_duration_s, bench_elapsed_s, run_quality, injection_status FROM runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    assert row == ("TestMission", 3600, 1800, 15, "ok", "injected")
     conn.close()
 
 
@@ -169,7 +187,17 @@ def test_bench_record_with_cpu_csv(tmp_path):
 
     result = runner.invoke(
         app,
-        ["bench", "record", str(miz), "--log", str(log), "--cpu", str(cpu), "--db", str(db)],
+        [
+            "bench",
+            "record",
+            str(miz),
+            "--log",
+            str(log),
+            "--cpu",
+            str(cpu),
+            "--db",
+            str(db),
+        ],
     )
     assert result.exit_code == 0, result.output
     assert "2 CPU samples" in result.output
@@ -184,7 +212,9 @@ def test_bench_record_no_bench_lines_warns(tmp_path):
     miz = tmp_path / "GoonFront.miz"
     _make_miz(miz)
     log = tmp_path / "dcs.log"
-    log.write_text("2026-04-25 10:00:00.000 INFO EDCORE: DCS started\n", encoding="utf-8")
+    log.write_text(
+        "2026-04-25 10:00:00.000 INFO EDCORE: DCS started\n", encoding="utf-8"
+    )
     db = tmp_path / "bench.db"
 
     result = runner.invoke(
@@ -195,7 +225,9 @@ def test_bench_record_no_bench_lines_warns(tmp_path):
 
     conn = open_db(db)
     count = conn.execute("SELECT COUNT(*) FROM bench_timeseries").fetchone()[0]
+    quality = conn.execute("SELECT run_quality FROM runs WHERE id=1").fetchone()[0]
     assert count == 0
+    assert quality == "no_bench_rows"
     conn.close()
 
 
@@ -206,23 +238,78 @@ def test_bench_record_missing_log(tmp_path):
 
     result = runner.invoke(
         app,
-        ["bench", "record", str(miz), "--log", str(tmp_path / "missing.log"), "--db", str(db)],
+        [
+            "bench",
+            "record",
+            str(miz),
+            "--log",
+            str(tmp_path / "missing.log"),
+            "--db",
+            str(db),
+        ],
     )
     assert result.exit_code == 2
 
 
-def test_bench_record_duration_from_bench_rows(tmp_path):
+def test_bench_record_duration_tracks_intended_and_bench_elapsed(tmp_path):
     miz = tmp_path / "GoonFront.miz"
     _make_miz(miz)
     log = tmp_path / "dcs.log"
     log.write_text(_BENCH_LOG, encoding="utf-8")
     db = tmp_path / "bench.db"
 
-    runner.invoke(app, ["bench", "record", str(miz), "--log", str(log), "--db", str(db)])
+    runner.invoke(
+        app,
+        [
+            "bench",
+            "record",
+            str(miz),
+            "--log",
+            str(log),
+            "--intended-duration",
+            "1800",
+            "--injection-status",
+            "injected",
+            "--db",
+            str(db),
+        ],
+    )
 
     conn = open_db(db)
-    duration = conn.execute("SELECT duration_s FROM runs WHERE id=1").fetchone()[0]
-    assert duration == 15  # max elapsed_s from _BENCH_LOG
+    duration, intended, elapsed, quality, injection = conn.execute(
+        "SELECT duration_s, intended_duration_s, bench_elapsed_s, run_quality, injection_status FROM runs WHERE id=1"
+    ).fetchone()
+    assert duration == 1800
+    assert intended == 1800
+    assert elapsed == 15
+    assert quality == "partial_bench_rows"
+    assert injection == "injected"
+    conn.close()
+
+
+def test_bench_record_stores_hard_stop_log_issue(tmp_path):
+    miz = tmp_path / "GoonFront.miz"
+    _make_miz(miz)
+    log = tmp_path / "dcs.log"
+    log.write_text(
+        '2026-04-27 08:09:02.503 ERROR   SCRIPTING (Main): Mission script error: [string "assert(loadfile(\\"C:/Scripts/Moose.lua\\"))()"]:1: no file \'C:/Scripts/Moose.lua\'\n',
+        encoding="utf-8",
+    )
+    db = tmp_path / "bench.db"
+
+    result = runner.invoke(
+        app, ["bench", "record", str(miz), "--log", str(log), "--db", str(db)]
+    )
+    assert result.exit_code == 0, result.output
+
+    conn = open_db(db)
+    quality, hard_stop = conn.execute(
+        "SELECT run_quality, hard_stop_error FROM runs WHERE id=1"
+    ).fetchone()
+    issues = get_log_issue_rows(conn, 1)
+    assert quality == "mission_script_hard_stop"
+    assert "Moose.lua" in hard_stop
+    assert issues[0]["issue_type"] == "hard_stop"
     conn.close()
 
 
@@ -241,7 +328,17 @@ def _seed_db(db: Path) -> None:
     cpu.write_text(_CPU_CSV, encoding="utf-8")
     runner.invoke(
         app,
-        ["bench", "record", str(miz), "--log", str(log), "--cpu", str(cpu), "--db", str(db)],
+        [
+            "bench",
+            "record",
+            str(miz),
+            "--log",
+            str(log),
+            "--cpu",
+            str(cpu),
+            "--db",
+            str(db),
+        ],
     )
 
 
@@ -252,6 +349,7 @@ def _mock_post(status_code: int = 201, body: dict | None = None):
     resp.text = json.dumps(body or {"id": "brun_abc123"})
     if status_code >= 400:
         import httpx
+
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
             "error", request=MagicMock(), response=resp
         )
@@ -268,11 +366,15 @@ def test_bench_push_latest_run(tmp_path):
         result = runner.invoke(
             app,
             [
-                "bench", "push",
+                "bench",
+                "push",
                 "https://example.com",
-                "--host-id", "host_abc",
-                "--key", "secret",
-                "--db", str(db),
+                "--host-id",
+                "host_abc",
+                "--key",
+                "secret",
+                "--db",
+                str(db),
             ],
         )
 
@@ -282,9 +384,14 @@ def test_bench_push_latest_run(tmp_path):
     call_kwargs = mock_post.call_args
     sent = call_kwargs.kwargs["json"]
     assert sent["mission"] == "GoonFront"
+    assert sent["run_quality"] == "ok"
+    assert "log_issues" in sent
     assert len(sent["bench_timeseries"]) == 3
     assert len(sent["cpu_timeseries"]) == 2
-    assert call_kwargs.kwargs["headers"] == {"X-Host-Id": "host_abc", "X-Agent-Key": "secret"}
+    assert call_kwargs.kwargs["headers"] == {
+        "X-Host-Id": "host_abc",
+        "X-Agent-Key": "secret",
+    }
 
 
 def test_bench_push_specific_run_id(tmp_path):
@@ -295,12 +402,17 @@ def test_bench_push_specific_run_id(tmp_path):
         result = runner.invoke(
             app,
             [
-                "bench", "push",
+                "bench",
+                "push",
                 "https://example.com",
-                "--host-id", "host_abc",
-                "--key", "secret",
-                "--run-id", "1",
-                "--db", str(db),
+                "--host-id",
+                "host_abc",
+                "--key",
+                "secret",
+                "--run-id",
+                "1",
+                "--db",
+                str(db),
             ],
         )
 
@@ -312,11 +424,15 @@ def test_bench_push_missing_db(tmp_path):
     result = runner.invoke(
         app,
         [
-            "bench", "push",
+            "bench",
+            "push",
             "https://example.com",
-            "--host-id", "host_abc",
-            "--key", "secret",
-            "--db", str(tmp_path / "missing.db"),
+            "--host-id",
+            "host_abc",
+            "--key",
+            "secret",
+            "--db",
+            str(tmp_path / "missing.db"),
         ],
     )
     assert result.exit_code == 2
@@ -326,15 +442,22 @@ def test_bench_push_http_error(tmp_path):
     db = tmp_path / "bench.db"
     _seed_db(db)
 
-    with patch("httpx.post", return_value=_mock_post(status_code=401, body={"detail": "Unauthorized"})):
+    with patch(
+        "httpx.post",
+        return_value=_mock_post(status_code=401, body={"detail": "Unauthorized"}),
+    ):
         result = runner.invoke(
             app,
             [
-                "bench", "push",
+                "bench",
+                "push",
                 "https://example.com",
-                "--host-id", "host_abc",
-                "--key", "wrong",
-                "--db", str(db),
+                "--host-id",
+                "host_abc",
+                "--key",
+                "wrong",
+                "--db",
+                str(db),
             ],
         )
 

--- a/tests/test_bench_log_issues.py
+++ b/tests/test_bench_log_issues.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from afterburner.bench.log_issues import parse_log_issues
+
+
+def test_parse_log_issues_always_reports_hard_stop():
+    log = """\
+2026-04-27 08:09:02.503 ERROR   SCRIPTING (Main): Mission script error: [string "assert(loadfile(lfs.writedir().."ColdWar/Core/loader.lua"))()"]:1: no file 'C:\\Users\\DCS\\ColdWar/Core/loader.lua'
+stack traceback:
+\t[C]: ?
+\t[C]: in function 'assert'
+"""
+
+    issues = parse_log_issues(log, repeated_threshold=10)
+
+    assert len(issues) == 1
+    assert issues[0].issue_type == "hard_stop"
+    assert "Mission script error:" in issues[0].signature
+    assert "stack traceback" in (issues[0].detail or "")
+
+
+def test_parse_log_issues_reports_repeated_scripting_errors_only_above_threshold():
+    line = (
+        "2026-04-27 08:09:02.503 ERROR   SCRIPTING (Main): "
+        '[string "l10n/DEFAULT/foo.lua"]:12: attempt to index local x\n'
+    )
+    low = (
+        "2026-04-27 08:09:03.503 ERROR   SCRIPTING (Main): "
+        '[string "l10n/DEFAULT/low.lua"]:1: one off\n'
+    )
+
+    issues = parse_log_issues(line * 10 + low, repeated_threshold=10)
+
+    repeated = [i for i in issues if i.issue_type == "repeated_scripting"]
+    assert len(repeated) == 1
+    assert repeated[0].count == 10
+    assert "foo.lua" in repeated[0].signature

--- a/tests/test_bench_native_events.py
+++ b/tests/test_bench_native_events.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from afterburner.bench.native_events import NativeEvent, parse_native_events
+
+
+def test_parse_native_events_extracts_dcs_scripting_event_fields():
+    text = (
+        "2026-04-26 20:49:26.819 INFO    Scripting (Main): "
+        "event:type=takeoff,initiatorPilotName=Potato,place=Andersen AFB,"
+        "t=37839.558,initiator_unit_type=F-4E-45MC,event_id=81229,\n"
+    )
+
+    assert parse_native_events(text) == [
+        NativeEvent(
+            timestamp=datetime(2026, 4, 26, 20, 49, 26, 819000),
+            type="takeoff",
+            fields={
+                "type": "takeoff",
+                "initiatorPilotName": "Potato",
+                "place": "Andersen AFB",
+                "t": "37839.558",
+                "initiator_unit_type": "F-4E-45MC",
+                "event_id": "81229",
+            },
+        )
+    ]
+
+
+def test_parse_native_events_accepts_uppercase_scripting_component():
+    text = (
+        "2026-04-26 20:58:40.531 INFO    SCRIPTING (Main): "
+        "event:type=score,initiatorPilotName=Potato,t=38393.258,amount=10,\n"
+    )
+
+    event = parse_native_events(text)[0]
+
+    assert event.type == "score"
+    assert event.player == "Potato"
+    assert event.elapsed_s == 38393.258
+
+
+def test_parse_native_events_ignores_non_event_lines():
+    text = "2026-04-26 20:00:00.000 INFO    APP (Main): Device plugged\n"
+
+    assert parse_native_events(text) == []
+
+
+def test_native_event_player_falls_back_to_target_pilot_name():
+    text = (
+        "2026-04-26 20:43:22.671 INFO    Scripting (Main): "
+        "event:type=crash,targetPilotName=Potato,t=37475.402,\n"
+    )
+
+    assert parse_native_events(text)[0].player == "Potato"
+
+
+def test_native_event_invalid_elapsed_returns_none():
+    text = (
+        "2026-04-26 20:43:22.671 INFO    Scripting (Main): "
+        "event:type=crash,initiatorPilotName=Potato,t=nope,\n"
+    )
+
+    assert parse_native_events(text)[0].elapsed_s is None


### PR DESCRIPTION

  ## Summary
  - store intended benchmark duration, observed bench elapsed time, run quality, injection status, and hard-stop script errors
  - parse DCS logs for mission script hard stops and repeated scripting errors
  - add native DCS scripting event parsing for player/event context
  - include benchmark diagnostics in pushed run payloads

  ## Testing
  - pytest
  - ruff check on touched benchmark files
