### PR TITLE
feat: add log suppression for confirmed-harmless engine errors

### DIFF
--- a/afterburner/log_analysis/correlator.py
+++ b/afterburner/log_analysis/correlator.py
@@ -24,6 +24,7 @@ from afterburner.log_analysis.patterns import (
     _LOG_001_ASSERT,
     ALL_PATTERNS,
     LOG_001,
+    SUPPRESSED_PATTERNS,
     LogPattern,
 )
 from afterburner.models.findings import ReportFinding
@@ -41,6 +42,13 @@ def correlate(events: list[LogEvent]) -> list[ReportFinding]:
 
     One finding is emitted per matched pattern (occurrence count in detail).
     """
+    # Filter out events matching any suppressed pattern
+    events = [
+        e
+        for e in events
+        if not any(p.matches(e.full_message) for p in SUPPRESSED_PATTERNS)
+    ]
+
     findings: list[ReportFinding] = []
 
     # LOG_001 — two-line pair check

--- a/afterburner/log_analysis/patterns.py
+++ b/afterburner/log_analysis/patterns.py
@@ -27,6 +27,8 @@ class LogPattern:
     contains: str | None = None
     # regex match — if set, compiled and matched against event.full_message
     pattern: str | None = None
+    # If True, the correlator skips lines matching this pattern
+    suppress: bool = False
 
     def matches(self, message: str) -> bool:
         if self.contains is not None and self.contains not in message:
@@ -105,6 +107,7 @@ LOG_004 = LogPattern(
     ),
     fix=None,
     pattern=r"Corrupt damage model",
+    suppress=True,
 )
 
 LOG_005 = LogPattern(
@@ -118,7 +121,12 @@ LOG_005 = LogPattern(
     ),
     fix=None,
     contains="attempt to index upvalue 'tcp' (a nil value)",
+    suppress=True,
 )
 
 # Ordered list used by the correlator (LOG_001 handled separately)
 ALL_PATTERNS: list[LogPattern] = [LOG_002, LOG_003, LOG_004, LOG_005]
+
+# Confirmed-harmless engine errors that are suppressed to reduce noise.
+# Suppressed patterns produce no findings and are not counted.
+SUPPRESSED_PATTERNS: list[LogPattern] = [p for p in ALL_PATTERNS if p.suppress]

--- a/tests/test_log_analysis.py
+++ b/tests/test_log_analysis.py
@@ -167,41 +167,29 @@ def test_log003_different_shape_name():
 
 
 # ---------------------------------------------------------------------------
-# LOG_004
+# LOG_004 — Suppressed
 # ---------------------------------------------------------------------------
 
 
-def test_log004_fires():
+def test_log004_is_suppressed():
     findings = correlate(_events(_DAMAGE_LINE))
-    assert any(f.rule_id == "LOG_004" for f in findings)
+    assert not any(f.rule_id == "LOG_004" for f in findings)
 
 
-def test_log004_severity_is_info():
-    findings = correlate(_events(_DAMAGE_LINE))
-    f = next(f for f in findings if f.rule_id == "LOG_004")
-    assert f.severity == Severity.INFO
-
-
-def test_log004_different_unit_type():
+def test_log004_different_unit_type_is_suppressed():
     line = "   10.000 INFO    SCRIPTING (Main): Error: Unit [Su-27]: Corrupt damage model"
     findings = correlate(_events(line))
-    assert any(f.rule_id == "LOG_004" for f in findings)
+    assert not any(f.rule_id == "LOG_004" for f in findings)
 
 
 # ---------------------------------------------------------------------------
-# LOG_005
+# LOG_005 — Suppressed
 # ---------------------------------------------------------------------------
 
 
-def test_log005_fires():
+def test_log005_is_suppressed():
     findings = correlate(_events(_TCP_LINE))
-    assert any(f.rule_id == "LOG_005" for f in findings)
-
-
-def test_log005_severity_is_info():
-    findings = correlate(_events(_TCP_LINE))
-    f = next(f for f in findings if f.rule_id == "LOG_005")
-    assert f.severity == Severity.INFO
+    assert not any(f.rule_id == "LOG_005" for f in findings)
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +200,18 @@ def test_log005_severity_is_info():
 def test_no_findings_for_clean_log():
     findings = correlate(_events(_UNRELATED_LINE))
     assert findings == []
+
+
+def test_suppressed_patterns_produce_no_findings():
+    # Mixed log with suppressed and non-suppressed errors
+    text = "\n".join([_RADIO_LINE, _DAMAGE_LINE, _TCP_LINE])
+    findings = correlate(parse_log(text))
+    ids = [f.rule_id for f in findings]
+
+    assert "LOG_002" in ids
+    assert "LOG_004" not in ids
+    assert "LOG_005" not in ids
+    assert len(findings) == 1
 
 
 def test_no_findings_empty():


### PR DESCRIPTION
Add suppress flag to LogPattern. Set suppress=True on LOG_004 (corrupt damage model) and LOG_005 (bhHook.lua TCP nil on disconnect) — both are non-fatal engine bugs that fire on every server and add noise to every report. Suppressed patterns produce no findings and are not counted.