### PR TITLE
fix: identify DCS instances by -w cmdline arg instead of child process names

### DIFF
--- a/afterburner/cli.py
+++ b/afterburner/cli.py
@@ -653,7 +653,7 @@ def bench_push(
     remote_id = resp.json().get("id", "?")
     con = Console()
     con.print(
-        f"[green]Pushed run #{resolved_id}[/green] → orchestrator run [bold]{remote_id}[/bold]  "
+        f"[green]Pushed run #{resolved_id}[/green] -> orchestrator run [bold]{remote_id}[/bold]  "
         f"[dim]{len(bench_rows)} bench, {len(cpu_rows)} CPU, {len(finding_rows)} findings, "
         f"{len(log_issue_rows)} log issues[/dim]"
     )

--- a/tests/test_bench_monitor.py
+++ b/tests/test_bench_monitor.py
@@ -13,28 +13,15 @@ class _MemInfo:
         self.rss = rss
 
 
-class _FakeChild:
-    def __init__(self, pid: int, name: str):
-        self.pid = pid
-        self._name = name
-
-    def name(self) -> str:
-        return self._name
-
-
 class _FakeProc:
     def __init__(
         self,
         pid: int,
         name: str,
-        children: list[_FakeChild] | None = None,
+        cmdline: list[str] | None = None,
     ):
         self.pid = pid
-        self.info = {"pid": pid, "name": name}
-        self._children = children or []
-
-    def children(self) -> list[_FakeChild]:
-        return self._children
+        self.info = {"pid": pid, "name": name, "cmdline": cmdline or []}
 
 
 class _FakePsutilProcess:
@@ -57,16 +44,7 @@ def test_is_dcs_process_name_matches_dcs_server_exe():
     assert bench_monitor._is_dcs_process_name("DCS_server.exe")
 
 
-def test_server_name_from_child_ignores_generic_children():
-    assert bench_monitor._server_name_from_child("conhost.exe") is None
-    assert bench_monitor._server_name_from_child("DCS_server.exe") is None
-
-
-def test_server_name_from_child_strips_exe_suffix():
-    assert bench_monitor._server_name_from_child("MemphisBBQ.exe") == "MemphisBBQ"
-
-
-def test_find_dcs_instances_uses_named_child(monkeypatch):
+def test_find_dcs_instances_uses_cmdline_w_arg(monkeypatch):
     monkeypatch.setattr(
         bench_monitor.psutil,
         "process_iter",
@@ -75,13 +53,13 @@ def test_find_dcs_instances_uses_named_child(monkeypatch):
             _FakeProc(
                 200,
                 "DCS_server.exe",
-                [_FakeChild(201, "conhost.exe"), _FakeChild(202, "MemphisBBQ.exe")],
+                ["C:\\DCS\\bin\\DCS_server.exe", "-w", "MemphisBBQ"],
             ),
         ],
     )
 
     assert bench_monitor.find_dcs_instances() == [
-        bench_monitor.DcsInstance("MemphisBBQ", 200, 202)
+        bench_monitor.DcsInstance("MemphisBBQ", 200, None)
     ]
 
 
@@ -89,7 +67,7 @@ def test_find_dcs_instances_falls_back_to_pid_name(monkeypatch):
     monkeypatch.setattr(
         bench_monitor.psutil,
         "process_iter",
-        lambda attrs: [_FakeProc(200, "DCS.exe")],
+        lambda attrs: [_FakeProc(200, "DCS.exe", ["C:\\DCS\\bin\\DCS.exe"])],
     )
 
     assert bench_monitor.find_dcs_instances() == [
@@ -152,7 +130,6 @@ def test_cmd_monitor_requires_server_when_multiple(monkeypatch):
 def test_monitor_writes_csv_row(monkeypatch, tmp_path):
     processes = {
         200: _FakePsutilProcess(cpu_pct=80.0, rss=512 * 1_048_576, threads=42),
-        201: _FakePsutilProcess(cpu_pct=20.0, rss=128 * 1_048_576, threads=5),
     }
     clock = {"now": 0.0}
 
@@ -171,7 +148,7 @@ def test_monitor_writes_csv_row(monkeypatch, tmp_path):
 
     out_path = tmp_path / "nested" / "bench_cpu.csv"
     bench_monitor.monitor(
-        bench_monitor.DcsInstance("MemphisBBQ", 200, 201),
+        bench_monitor.DcsInstance("MemphisBBQ", 200, None),
         interval=5.0,
         out_path=out_path,
         duration=5.0,
@@ -188,8 +165,8 @@ def test_monitor_writes_csv_row(monkeypatch, tmp_path):
             "cpu_pct_raw": "80.0",
             "mem_mb": "512.0",
             "threads": "42",
-            "child_cpu_pct": "5.0",
-            "child_mem_mb": "128.0",
+            "child_cpu_pct": "",
+            "child_mem_mb": "",
         }
     ]
 

--- a/tools/bench_monitor.py
+++ b/tools/bench_monitor.py
@@ -1,9 +1,8 @@
 """
 DCS server CPU/memory benchmark monitor.
 
-Finds DCS.exe / DCS_server.exe instances by their child process names
-(MemphisBBQ, SouthernBBQ, etc.) and samples performance metrics every N
-seconds into a CSV file.
+Finds DCS_server.exe instances by their -w (saved games) argument and samples
+performance metrics every N seconds into a CSV file.
 
 Usage:
     python bench_monitor.py --list
@@ -50,40 +49,32 @@ _CSV_HEADER = [
 
 
 def find_dcs_instances() -> list[DcsInstance]:
-    """Return all running DCS.exe instances, identified by their named child process."""
+    """Return all running DCS_server.exe instances, identified by their -w argument."""
     instances: list[DcsInstance] = []
 
-    for proc in psutil.process_iter(["pid", "name"]):
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
             name = proc.info["name"] or ""
             if not _is_dcs_process_name(name):
                 continue
 
-            children = proc.children()
-            if children:
-                for child in children:
-                    try:
-                        child_name = _server_name_from_child(child.name())
-                        if child_name is None:
-                            continue
-                        instances.append(
-                            DcsInstance(
-                                server_name=child_name,
-                                parent_pid=proc.pid,
-                                child_pid=child.pid,
-                            )
-                        )
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
-                        pass
-            else:
-                # No named child — list as unnamed
-                instances.append(
-                    DcsInstance(
-                        server_name=f"DCS_{proc.pid}",
-                        parent_pid=proc.pid,
-                        child_pid=None,
-                    )
+            cmdline = proc.info["cmdline"] or []
+            server_name = None
+            if "-w" in cmdline:
+                idx = cmdline.index("-w")
+                if idx + 1 < len(cmdline):
+                    server_name = cmdline[idx + 1]
+
+            if server_name is None:
+                server_name = f"DCS_{proc.pid}"
+
+            instances.append(
+                DcsInstance(
+                    server_name=server_name,
+                    parent_pid=proc.pid,
+                    child_pid=None,
                 )
+            )
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 
@@ -93,13 +84,6 @@ def find_dcs_instances() -> list[DcsInstance]:
 def _is_dcs_process_name(name: str) -> bool:
     normalized = name.lower()
     return normalized.endswith(".exe") and "dcs" in normalized
-
-
-def _server_name_from_child(name: str) -> str | None:
-    child_name = name.removesuffix(".exe")
-    if child_name.lower() in {"conhost", "werfault", "dcs", "dcs_server"}:
-        return None
-    return child_name
 
 
 def monitor(
@@ -120,13 +104,6 @@ def monitor(
 
     # Prime cpu_percent — first call always returns 0.0
     parent.cpu_percent(interval=None)
-    child_proc = None
-    if instance.child_pid:
-        try:
-            child_proc = psutil.Process(instance.child_pid)
-            child_proc.cpu_percent(interval=None)
-        except psutil.NoSuchProcess:
-            child_proc = None
 
     cpu_count = psutil.cpu_count(logical=True) or 1
     out_path = Path(out_path)
@@ -171,17 +148,6 @@ def monitor(
                     print(f"\n[{elapsed}s] DCS process exited.")
                     break
 
-                child_cpu = ""
-                child_mem = ""
-                if child_proc:
-                    try:
-                        child_cpu = round(
-                            child_proc.cpu_percent(interval=None) / cpu_count, 2
-                        )
-                        child_mem = round(child_proc.memory_info().rss / 1_048_576, 1)
-                    except psutil.NoSuchProcess:
-                        child_proc = None
-
                 writer.writerow(
                     [
                         now_utc,
@@ -190,8 +156,8 @@ def monitor(
                         raw_cpu,
                         mem_mb,
                         threads,
-                        child_cpu,
-                        child_mem,
+                        "",
+                        "",
                     ]
                 )
                 f.flush()
@@ -211,12 +177,10 @@ def cmd_list() -> None:
     if not instances:
         print("No DCS.exe instances found.")
         return
-    print(f"{'Server':<25} {'Parent PID':>10} {'Child PID':>10}")
-    print("-" * 48)
+    print(f"{'Server':<25} {'Parent PID':>10}")
+    print("-" * 38)
     for inst in instances:
-        print(
-            f"{inst.server_name:<25} {inst.parent_pid:>10} {inst.child_pid or '—':>10}"
-        )
+        print(f"{inst.server_name:<25} {inst.parent_pid:>10}")
 
 
 def cmd_monitor(args: argparse.Namespace) -> None:


### PR DESCRIPTION
## Summary

- `find_dcs_instances()` was looking for child processes named after the server (e.g. `MemphisBBQ.exe`), which DCS never spawns
- DCS passes the server/saved-games name via `-w` on the command line (`DCS_server.exe -w MemphisBBQ`)
- Fix reads `cmdline` from the process and extracts the `-w` argument instead
- Removes dead `_server_name_from_child` function
- Updates tests to match the new discovery mechanism

No interface changes — `--server MemphisBBQ` works the same way; the orchestrator/agent flow is unaffected.